### PR TITLE
performance: move rules to dictionary

### DIFF
--- a/simplemma/dictionary_pickler.py
+++ b/simplemma/dictionary_pickler.py
@@ -8,12 +8,12 @@ from typing import Dict, List, Optional
 
 try:
     from .constants import LANGLIST
-    from .rules import apply_rules
+    from .rules import APPLY_RULES
     from .utils import levenshtein_dist
 # local error, also ModuleNotFoundError for Python >= 3.6
 except ImportError:  # pragma: no cover
     from constants import LANGLIST  # type: ignore
-    from rules import apply_rules  # type: ignore
+    from rules import APPLY_RULES  # type: ignore
     from utils import levenshtein_dist  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
@@ -77,8 +77,10 @@ def _read_dict(filepath: str, langcode: str, silent: bool) -> Dict[str, str]:
             if len(columns[0]) > 6 and len(columns[1]) == 1:
                 continue
             # tackled by rules
-            if len(columns[1]) > 6:  # columns[1] != columns[0]
-                rule = apply_rules(columns[1], langcode)
+            if (
+                len(columns[1]) > 6 and langcode in APPLY_RULES
+            ):  # columns[1] != columns[0]
+                rule = APPLY_RULES[langcode](columns[1], False)
                 if rule == columns[0]:
                     continue
                 if rule is not None and rule != columns[1]:

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -112,19 +112,6 @@ def test_logic() -> None:
         == "getestet"
     )
 
-    # prefixes
-    dictionaries = dictionary_factory.get_dictionaries(("de", "ru"))
-    deDict = dictionaries["de"]
-    assert (
-        simplemma.lemmatizer._prefix_search("zerlemmatisiertes", "de", deDict)
-        == "zerlemmatisiert"
-    )
-    ruDict = dictionaries["ru"]
-    assert (
-        simplemma.lemmatizer._prefix_search("зафиксированные", "ru", ruDict)
-        == "зафиксированный"
-    )
-
 
 def test_convenience() -> None:
     """Test convenience functions."""

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,9 +2,21 @@
 
 import logging
 
-from simplemma.rules import apply_rules, apply_de, apply_en, apply_fi, apply_nl
+from simplemma.rules import (
+    apply_de,
+    apply_en,
+    apply_fi,
+    apply_nl,
+    APPLY_RULES,
+    FIND_PREFIXES,
+)
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+def test_test_prefixes_de():
+    assert FIND_PREFIXES["de"]("zerlemmatisiertes") == "zer"
+    assert FIND_PREFIXES["de"]("abzugshaube") == None
 
 
 def test_apply_de() -> None:
@@ -151,13 +163,17 @@ def test_apply_fi() -> None:
     assert apply_fi("zzzzztteja") == "zzzzztti"
 
 
+def test_test_prefixes_ru():
+    assert FIND_PREFIXES["ru"]("зафиксированные") == "за"
+
+
 def test_apply_rules() -> None:
     """Test rules on all available languages."""
-    assert apply_rules("Pfifferlinge", "de", greedy=True) == "Pfifferling"
-    assert apply_rules("Pfifferlinge", "en", greedy=True) is None
-    assert apply_rules("atonements", "de") is None
-    assert apply_rules("atonements", "en") == "atonement"
-    assert apply_rules("brieven", "nl") == "brief"
-    assert apply_rules("liikenaisessa", "fi") == "liikenainen"
-    assert apply_rules("pracowaliście", "pl") == "pracować"
-    assert apply_rules("безгра́мотностью", "ru") == "безгра́мотность"
+    assert APPLY_RULES["de"]("Pfifferlinge", True) == "Pfifferling"
+    assert APPLY_RULES["en"]("Pfifferlinge", True) is None
+    assert APPLY_RULES["de"]("atonements", False) is None
+    assert APPLY_RULES["en"]("atonements", False) == "atonement"
+    assert APPLY_RULES["nl"]("brieven", False) == "brief"
+    assert APPLY_RULES["fi"]("liikenaisessa", False) == "liikenainen"
+    assert APPLY_RULES["pl"]("pracowaliście", False) == "pracować"
+    assert APPLY_RULES["ru"]("безгра́мотностью", False) == "безгра́мотность"


### PR DESCRIPTION
Doing a dictionary lookup should be much faster than the if-else block.

The mechanism to see the languages with rules is more solid just looking at the dictionary keys.

I've applied the same logic to the prefix processing.

My next step is to create a `rules` folder where each language has its own file exporting the methods to apply the rules and apply the prefixes.

With all this is much easier to add new rules and manage them.
It's also a first step to wrap rules in a class and make them configurable.