### PR TITLE
refactor: language detector improvements

### DIFF
--- a/simplemma/__init__.py
+++ b/simplemma/__init__.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 __version__ = "0.9.1"
 
 
-from .language_detector import in_target_language, lang_detector
+from .language_detector import in_target_language, langdetect
 from .lemmatizer import lemmatize, lemma_iterator, text_lemmatizer, is_known
 from .tokenizer import simple_tokenizer
 from .token_sampler import TokenSampler

--- a/simplemma/__init__.py
+++ b/simplemma/__init__.py
@@ -10,5 +10,6 @@ __version__ = "0.9.1"
 from .language_detector import in_target_language, lang_detector
 from .lemmatizer import lemmatize, lemma_iterator, text_lemmatizer, is_known
 from .tokenizer import simple_tokenizer
+from .token_sampler import TokenSampler
 from .dictionary_factory import DictionaryFactory
 from .dictionary_pickler import *

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -86,24 +86,23 @@ def lang_detector(
     results = LanguageDetector(
         dictionary_factory, token_sampler
     ).get_text_percentage_in_each_language(text, lang, greedy)
-    # post-processing
-    if len(results) == 1:
-        return _convert_results_to_sorted_list(results)
-    # in case of ex-aequo
     list_results = _convert_results_to_sorted_list(results)
+
+    # post-processing
+    if len(list_results) == 1:
+        return list_results
+    # in case of ex-aequo
     if greedy is False and list_results[0][1] == list_results[1][1]:
         results = LanguageDetector(
             dictionary_factory, token_sampler
         ).get_text_percentage_in_each_language(text, lang, greedy=True)
-
-    list_results = _convert_results_to_sorted_list(results)
+        list_results = _convert_results_to_sorted_list(results)
     # in case of ex-aequo use other token sampling to discriminate
     if not greedy and list_results[0][1] == list_results[1][1]:
         results = LanguageDetector(
             dictionary_factory, backup_sampler
         ).get_text_percentage_in_each_language(text, lang, greedy=True)
-
-    list_results = _convert_results_to_sorted_list(results)
+        list_results = _convert_results_to_sorted_list(results)
     return list_results
 
 

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -43,15 +43,6 @@ class TokenSampler:
         return [item[0] for item in counter.most_common(self.max_tokens)]
 
 
-class RelaxedTokenSampler(TokenSampler):
-    def __init__(self) -> None:
-        super().__init__(
-            tokenizer=Tokenizer(RELAXED_SPLIT_INPUT),
-            max_tokens=1000,
-            capitalized_threshold=0,
-        )
-
-
 def in_target_language(
     text: str,
     lang: Optional[Union[str, Tuple[str, ...]]] = None,
@@ -85,7 +76,11 @@ def lang_detector(
     greedy: bool = False,
     dictionary_factory: DictionaryFactory = DictionaryFactory(),
     token_sampler: TokenSampler = TokenSampler(),
-    backup_sampler: TokenSampler = RelaxedTokenSampler(),
+    backup_sampler: TokenSampler = TokenSampler(
+        tokenizer=Tokenizer(RELAXED_SPLIT_INPUT),
+        max_tokens=1000,
+        capitalized_threshold=0,
+    ),
 ) -> List[Tuple[str, float]]:
     """Determine which proportion of the text is in the target language(s)."""
     results = LanguageDetector(dictionary_factory, token_sampler).lang_detector(

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -49,10 +49,10 @@ def langdetect(
 
 
 def _as_list(results: Dict[str, float]) -> List[Tuple[str, float]]:
+    "Convert the results to a sorted list and switch unknown to the end."
     list_results: List[Tuple[str, float]] = sorted(
         results.items(), key=itemgetter(1), reverse=True
     )
-    "Convert the results to a sorted list and switch unknown to the end."
     for i, item in enumerate(list_results):
         if item[0] == "unk":
             pair = list_results.pop(i)

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -36,7 +36,7 @@ def _convert_results_to_sorted_list(
     return list_results
 
 
-def lang_detector(
+def langdetect(
     text: str,
     lang: Optional[Union[str, Tuple[str, ...]]] = None,
     greedy: bool = False,
@@ -157,7 +157,9 @@ class LanguageDetector:
         token_samplers: List[TokenSampler] = [TokenSampler()],
     ) -> str:
         for token_sampler in token_samplers:
-            result = self.detect_tokens_main_language(token_sampler.sample_tokens(text), lang, greedy)
+            result = self.detect_tokens_main_language(
+                token_sampler.sample_tokens(text), lang, greedy
+            )
             if result != "unk":
                 return result
 

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -163,4 +163,15 @@ class LanguageDetector:
     ) -> float:
         """Determine which proportion of the text is in the target language(s)."""
 
-        return 1 - self.get_text_percentage_in_each_languages(text, lang, greedy)["unk"]
+        return sum(
+            [
+                percentage
+                for (
+                    lang_code,
+                    percentage,
+                ) in self.get_text_percentage_in_each_languages(
+                    text, lang, greedy
+                ).items()
+                if lang_code != "unk"
+            ]
+        )

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -115,14 +115,12 @@ class LanguageDetector:
         text: str,
     ) -> float:
         return sum(
-            [
-                percentage
-                for (
-                    lang_code,
-                    percentage,
-                ) in self.proportion_in_each_language(text).items()
-                if lang_code != "unk"
-            ]
+            percentage
+            for (
+                lang_code,
+                percentage,
+            ) in self.proportion_in_each_language(text).items()
+            if lang_code != "unk"
         )
 
     def main_language(

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -125,7 +125,8 @@ class LanguageDetector:
         greedy: bool = False,
     ) -> Dict[str, float]:
         """Determine which proportion of the text is in the target language(s).
-        Perform a first run and further discriminate between the results if necessary."""
+        Perform a first run and further discriminate between the results if necessary.
+        """
 
         tokens = self.token_sampler.sample_tokens(text)
         total_tokens = len(tokens)

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -108,6 +108,8 @@ def lang_detector(
 
 
 class LanguageDetector:
+    __slots__ = ["dictionary_factory", "token_sampler"]
+
     def __init__(
         self,
         dictionary_factory: DictionaryFactory = DictionaryFactory(),

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -85,7 +85,7 @@ def lang_detector(
     """Determine which proportion of the text is in the target language(s)."""
     results = LanguageDetector(
         dictionary_factory, token_sampler
-    ).get_text_percentage_in_each_languages(text, lang, greedy)
+    ).get_text_percentage_in_each_language(text, lang, greedy)
     # post-processing
     if len(results) == 1:
         return _convert_results_to_sorted_list(results)
@@ -94,14 +94,14 @@ def lang_detector(
     if greedy is False and list_results[0][1] == list_results[1][1]:
         results = LanguageDetector(
             dictionary_factory, token_sampler
-        ).get_text_percentage_in_each_languages(text, lang, greedy=True)
+        ).get_text_percentage_in_each_language(text, lang, greedy=True)
 
     list_results = _convert_results_to_sorted_list(results)
     # in case of ex-aequo use other token sampling to discriminate
     if not greedy and list_results[0][1] == list_results[1][1]:
         results = LanguageDetector(
             dictionary_factory, backup_sampler
-        ).get_text_percentage_in_each_languages(text, lang, greedy=True)
+        ).get_text_percentage_in_each_language(text, lang, greedy=True)
 
     list_results = _convert_results_to_sorted_list(results)
     return list_results
@@ -118,7 +118,7 @@ class LanguageDetector:
         self.dictionary_factory = dictionary_factory
         self.token_sampler = token_sampler
 
-    def get_text_percentage_in_each_languages(
+    def get_text_percentage_in_each_language(
         self,
         text: str,
         lang: Optional[Union[str, Tuple[str, ...]]] = None,
@@ -169,7 +169,7 @@ class LanguageDetector:
                 for (
                     lang_code,
                     percentage,
-                ) in self.get_text_percentage_in_each_languages(
+                ) in self.get_text_percentage_in_each_language(
                     text, lang, greedy
                 ).items()
                 if lang_code != "unk"

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -125,18 +125,15 @@ class LanguageDetector:
     def main_language(
         self,
         text: str,
-        additional_token_samplers: List[TokenSampler] = [
-            RelaxedMostCommonTokenSampler()
+        token_samplers: List[TokenSampler] = [
+            MostCommonTokenSampler(),
+            RelaxedMostCommonTokenSampler(),
         ],
     ) -> str:
-        original_token_sampler = self.token_sampler
-
-        for token_sampler in [self.token_sampler] + additional_token_samplers:
+        for token_sampler in token_samplers:
             self.token_sampler = token_sampler
             list_results = _as_list(self.proportion_in_each_language(text))
             if len(list_results) > 1 and list_results[0][1] != list_results[1][1]:
                 return list_results[0][0]
-
-        self.token_sampler = original_token_sampler
 
         return "unk"

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -51,9 +51,9 @@ def in_target_language(
     token_sampler: TokenSampler = TokenSampler(),
 ) -> float:
     """Determine which proportion of the text is in the target language(s)."""
-    return LanguageDetector(dictionary_factory, token_sampler).in_target_language(
-        text, lang, greedy
-    )
+    return LanguageDetector(
+        dictionary_factory, token_sampler
+    ).get_text_percentage_in_all_languages(text, lang, greedy)
 
 
 def _convert_results_to_sorted_list(
@@ -83,25 +83,25 @@ def lang_detector(
     ),
 ) -> List[Tuple[str, float]]:
     """Determine which proportion of the text is in the target language(s)."""
-    results = LanguageDetector(dictionary_factory, token_sampler).lang_detector(
-        text, lang, greedy
-    )
+    results = LanguageDetector(
+        dictionary_factory, token_sampler
+    ).get_text_percentage_in_each_languages(text, lang, greedy)
     # post-processing
     if len(results) == 1:
         return _convert_results_to_sorted_list(results)
     # in case of ex-aequo
     list_results = _convert_results_to_sorted_list(results)
     if greedy is False and list_results[0][1] == list_results[1][1]:
-        results = LanguageDetector(dictionary_factory, token_sampler).lang_detector(
-            text, lang, greedy=True
-        )
+        results = LanguageDetector(
+            dictionary_factory, token_sampler
+        ).get_text_percentage_in_each_languages(text, lang, greedy=True)
 
     list_results = _convert_results_to_sorted_list(results)
     # in case of ex-aequo use other token sampling to discriminate
     if not greedy and list_results[0][1] == list_results[1][1]:
-        results = LanguageDetector(dictionary_factory, backup_sampler).lang_detector(
-            text, lang, greedy=True
-        )
+        results = LanguageDetector(
+            dictionary_factory, backup_sampler
+        ).get_text_percentage_in_each_languages(text, lang, greedy=True)
 
     list_results = _convert_results_to_sorted_list(results)
     return list_results
@@ -116,7 +116,7 @@ class LanguageDetector:
         self.dictionary_factory = dictionary_factory
         self.token_sampler = token_sampler
 
-    def lang_detector(
+    def get_text_percentage_in_each_languages(
         self,
         text: str,
         lang: Optional[Union[str, Tuple[str, ...]]] = None,
@@ -152,7 +152,7 @@ class LanguageDetector:
         results["unk"] = unknown_tokens_count / total_tokens
         return results
 
-    def in_target_language(
+    def get_text_percentage_in_all_languages(
         self,
         text: str,
         lang: Optional[Union[str, Tuple[str, ...]]] = None,
@@ -160,4 +160,4 @@ class LanguageDetector:
     ) -> float:
         """Determine which proportion of the text is in the target language(s)."""
 
-        return 1 - self.lang_detector(text, lang, greedy)["unk"]
+        return 1 - self.get_text_percentage_in_each_languages(text, lang, greedy)["unk"]

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -65,10 +65,11 @@ class MostCommonTokenSampler(AbstractBaseTokenSampler):
 
 
 class RelaxedMostCommonTokenSampler(MostCommonTokenSampler):
+    __slots__ = ["capitalized_threshold", "sample_size"]
     def __init__(
         self,
-        tokenizer=Tokenizer(RELAXED_SPLIT_INPUT),
-        sample_size=1000,
-        capitalized_threshold=0,
+        tokenizer: Tokenizer = Tokenizer(RELAXED_SPLIT_INPUT),
+        sample_size: int = 1000,
+        capitalized_threshold: float = 0,
     ) -> None:
         super().__init__(tokenizer, sample_size, capitalized_threshold)

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -65,8 +65,6 @@ class MostCommonTokenSampler(AbstractBaseTokenSampler):
 
 
 class RelaxedMostCommonTokenSampler(MostCommonTokenSampler):
-    __slots__ = ["capitalized_threshold", "sample_size"]
-
     def __init__(
         self,
         tokenizer: Tokenizer = Tokenizer(RELAXED_SPLIT_INPUT),

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -1,7 +1,7 @@
 import re
 
-
-from typing import List
+from abc import ABC
+from typing import Iterable, List, Protocol
 from collections import Counter
 from .tokenizer import Tokenizer
 
@@ -9,24 +9,51 @@ SPLIT_INPUT = re.compile(r"[^\W\d_]{3,}")
 RELAXED_SPLIT_INPUT = re.compile(r"[\w-]{3,}")
 
 
-class TokenSampler:
-    __slots__ = ["capitalized_threshold", "max_tokens", "tokenizer"]
+class TokenSampler(Protocol):
+    def sample_text(self, text: str) -> List[str]:
+        raise NotImplementedError
+
+    def sample_tokens(self, tokens: Iterable[str]) -> List[str]:
+        raise NotImplementedError
+
+
+class AbstractBaseTokenSampler(ABC, TokenSampler):
+    __slots__ = ["tokenizer"]
 
     def __init__(
         self,
         tokenizer: Tokenizer = Tokenizer(SPLIT_INPUT),
-        max_tokens: int = 100,
-        capitalized_threshold: float = 0.8,
     ) -> None:
         self.tokenizer = tokenizer
-        self.max_tokens = max_tokens
+
+    def sample_text(self, text: str) -> List[str]:
+        return self.sample_tokens(self.tokenizer.split_text(text))
+
+    def sample_tokens(self, tokens: Iterable[str]) -> List[str]:
+        raise NotImplementedError
+
+
+class MostCommonTokenSampler(AbstractBaseTokenSampler):
+    __slots__ = ["capitalized_threshold", "sample_size"]
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer = Tokenizer(SPLIT_INPUT),
+        sample_size: int = 100,
+        capitalized_threshold: float = 0.8,
+    ) -> None:
+        super().__init__(tokenizer)
+        self.sample_size = sample_size
         self.capitalized_threshold = capitalized_threshold
 
-    def sample_tokens(self, text: str) -> List[str]:
+    def sample_text(self, text: str) -> List[str]:
+        return self.sample_tokens(self.tokenizer.split_text(text))
+
+    def sample_tokens(self, tokens: Iterable[str]) -> List[str]:
         """Extract potential tokens, scramble them, potentially get rid of capitalized
         ones, and return the most frequent."""
 
-        counter = Counter(token for token in self.tokenizer.split_text(text))
+        counter = Counter(tokens)
 
         if self.capitalized_threshold > 0:
             deletions = [token for token in counter if token[0].isupper()]
@@ -34,4 +61,14 @@ class TokenSampler:
                 for token in deletions:
                     del counter[token]
 
-        return [item[0] for item in counter.most_common(self.max_tokens)]
+        return [item[0] for item in counter.most_common(self.sample_size)]
+
+
+class RelaxedMostCommonTokenSampler(MostCommonTokenSampler):
+    def __init__(
+        self,
+        tokenizer=Tokenizer(RELAXED_SPLIT_INPUT),
+        sample_size=1000,
+        capitalized_threshold=0,
+    ) -> None:
+        super().__init__(tokenizer, sample_size, capitalized_threshold)

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -1,7 +1,7 @@
 import re
 
 from abc import ABC
-from typing import Iterable, List, Protocol
+from typing import Iterable, List
 from collections import Counter
 from .tokenizer import Tokenizer
 
@@ -9,15 +9,7 @@ SPLIT_INPUT = re.compile(r"[^\W\d_]{3,}")
 RELAXED_SPLIT_INPUT = re.compile(r"[\w-]{3,}")
 
 
-class TokenSampler(Protocol):
-    def sample_text(self, text: str) -> List[str]:
-        raise NotImplementedError
-
-    def sample_tokens(self, tokens: Iterable[str]) -> List[str]:
-        raise NotImplementedError
-
-
-class AbstractBaseTokenSampler(ABC, TokenSampler):
+class TokenSampler(ABC):
     __slots__ = ["tokenizer"]
 
     def __init__(
@@ -33,7 +25,7 @@ class AbstractBaseTokenSampler(ABC, TokenSampler):
         raise NotImplementedError
 
 
-class MostCommonTokenSampler(AbstractBaseTokenSampler):
+class MostCommonTokenSampler(TokenSampler):
     __slots__ = ["capitalized_threshold", "sample_size"]
 
     def __init__(

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -1,0 +1,37 @@
+import re
+
+
+from typing import List
+from collections import Counter
+from .tokenizer import Tokenizer
+
+SPLIT_INPUT = re.compile(r"[^\W\d_]{3,}")
+RELAXED_SPLIT_INPUT = re.compile(r"[\w-]{3,}")
+
+
+class TokenSampler:
+    __slots__ = ["capitalized_threshold", "max_tokens", "tokenizer"]
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer = Tokenizer(SPLIT_INPUT),
+        max_tokens: int = 100,
+        capitalized_threshold: float = 0.8,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.max_tokens = max_tokens
+        self.capitalized_threshold = capitalized_threshold
+
+    def sample_tokens(self, text: str) -> List[str]:
+        """Extract potential tokens, scramble them, potentially get rid of capitalized
+        ones, and return the most frequent."""
+
+        counter = Counter(token for token in self.tokenizer.split_text(text))
+
+        if self.capitalized_threshold > 0:
+            deletions = [token for token in counter if token[0].isupper()]
+            if len(deletions) < self.capitalized_threshold * len(counter):
+                for token in deletions:
+                    del counter[token]
+
+        return [item[0] for item in counter.most_common(self.max_tokens)]

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -66,6 +66,7 @@ class MostCommonTokenSampler(AbstractBaseTokenSampler):
 
 class RelaxedMostCommonTokenSampler(MostCommonTokenSampler):
     __slots__ = ["capitalized_threshold", "sample_size"]
+
     def __init__(
         self,
         tokenizer: Tokenizer = Tokenizer(RELAXED_SPLIT_INPUT),

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -3,11 +3,13 @@
 import logging
 from typing import List
 
+from simplemma.tokenizer import Tokenizer
+
 from simplemma.language_detector import (
     in_target_language,
     lang_detector,
-    RelaxedTokenSampler,
     TokenSampler,
+    RELAXED_SPLIT_INPUT,
 )
 
 logging.basicConfig(level=logging.DEBUG)
@@ -33,8 +35,13 @@ def test_token_sampler():
     sampler = TokenSampler(capitalized_threshold=0, max_tokens=1)
     assert sampler.sample_tokens("Efgh Efgh ijkl mn") == ["Efgh"]
 
-    relaxed = RelaxedTokenSampler()
+    relaxed = TokenSampler(
+        tokenizer=Tokenizer(splitting_regex=RELAXED_SPLIT_INPUT),
+        max_tokens=1000,
+        capitalized_threshold=0,
+    )
     assert relaxed.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
+
     custom = CustomTokenSampler(3)
     assert custom.sample_tokens("ABCD Efgh ijkl mn") == []
 

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -60,9 +60,9 @@ def test_proportion_in_each_language() -> None:
 
     lang = ("cs", "en")
     text = '"Moderní studie narazily na několik tajemství." Extracted from Wikipedia.'
-    assert LanguageDetector(lang=lang).proportion_in_each_language(
-        text, token_sampler=CustomTokenSampler(6)
-    ) == {
+    assert LanguageDetector(
+        lang=lang, token_sampler=CustomTokenSampler(6)
+    ).proportion_in_each_language(text) == {
         "en": 1.0,
         "cs": 0.0,
         "unk": 0.0,
@@ -100,9 +100,9 @@ def test_in_target_language() -> None:
     lang = "en"
     text = '"Moderní studie narazily na několik tajemství." Extracted from Wikipedia.'
     assert (
-        LanguageDetector(lang=lang).proportion_in_target_languages(
-            text, token_sampler=CustomTokenSampler(6)
-        )
+        LanguageDetector(
+            lang=lang, token_sampler=CustomTokenSampler(6)
+        ).proportion_in_target_languages(text)
         == in_target_language(
             text,
             lang=lang,
@@ -113,7 +113,6 @@ def test_in_target_language() -> None:
 
 
 def test_main_language():
-    # language detection
     text = "Dieser Satz ist auf Deutsch."
     lang = ("de", "en")
     assert (
@@ -127,3 +126,11 @@ def test_main_language():
         == langdetect(text, lang=lang, greedy=False)[0][0]
         == "de"
     )
+
+    # text = "Dieser Satz ist auf Deutsch. Y esta está en Español."
+    # lang = ("de", "es")
+    # assert (
+    #     LanguageDetector(lang=lang, greedy=False).main_language(text)
+    #     == langdetect(text, lang=lang, greedy=False)[0][0]
+    #     == "unk"
+    # )

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -86,7 +86,7 @@ def test_detection() -> None:
     assert lang_detector(
         '"Moderní studie narazily na několik tajemství." Extracted from Wikipedia.',
         lang=("cs", "en"),
-        token_sampler=CustomTokenSampler(6),
+        token_samplers=[CustomTokenSampler(6)],
     ) == [("en", 1.0), ("cs", 0.0), ("unk", 0.0)]
 
 

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -1,49 +1,15 @@
 """Tests for Simplemma's language detection utilities."""
 
 import logging
-from typing import List
-
-from simplemma.tokenizer import Tokenizer
 
 from simplemma.language_detector import (
     in_target_language,
     langdetect,
-    TokenSampler,
-    RELAXED_SPLIT_INPUT,
 )
 
+from .test_token_sampler import CustomTokenSampler
+
 logging.basicConfig(level=logging.DEBUG)
-
-
-class CustomTokenSampler(TokenSampler):
-    def __init__(self, skip_tokens: int) -> None:
-        super().__init__()
-        self.skip_tokens: int = skip_tokens
-
-    def sample_tokens(self, text: str) -> List[str]:
-        return list(self.tokenizer.split_text(text))[self.skip_tokens :]
-
-
-def test_token_sampler():
-    sampler = TokenSampler()
-    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ijkl"]
-    assert sampler.sample_tokens("Abcd_E Abcde") == ["Abcd", "Abcde"]
-
-    sampler = TokenSampler(capitalized_threshold=0)
-    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
-
-    sampler = TokenSampler(capitalized_threshold=0, max_tokens=1)
-    assert sampler.sample_tokens("Efgh Efgh ijkl mn") == ["Efgh"]
-
-    relaxed = TokenSampler(
-        tokenizer=Tokenizer(splitting_regex=RELAXED_SPLIT_INPUT),
-        max_tokens=1000,
-        capitalized_threshold=0,
-    )
-    assert relaxed.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
-
-    custom = CustomTokenSampler(3)
-    assert custom.sample_tokens("ABCD Efgh ijkl mn") == []
 
 
 def test_detection() -> None:

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -7,7 +7,7 @@ from simplemma.tokenizer import Tokenizer
 
 from simplemma.language_detector import (
     in_target_language,
-    lang_detector,
+    langdetect,
     TokenSampler,
     RELAXED_SPLIT_INPUT,
 )
@@ -48,42 +48,40 @@ def test_token_sampler():
 
 def test_detection() -> None:
     # sanity checks
-    assert lang_detector(" aa ", lang=("de", "en"), greedy=True) == [("unk", 1)]
+    assert langdetect(" aa ", lang=("de", "en"), greedy=True) == [("unk", 1)]
     text = "Test test"
 
-    assert lang_detector(text, lang=("de", "en"), greedy=False) == [
+    assert langdetect(text, lang=("de", "en"), greedy=False) == [
         ("de", 1.0),
         ("en", 1.0),
         ("unk", 0.0),
     ]
-    assert lang_detector(text, lang=("de", "en"), greedy=True) == [
+    assert langdetect(text, lang=("de", "en"), greedy=True) == [
         ("de", 1.0),
         ("en", 1.0),
         ("unk", 0.0),
     ]
 
     # language detection
-    results = lang_detector(
+    results = langdetect(
         "Dieser Satz ist auf Deutsch.", lang=("de", "en"), greedy=False
     )
     assert results[0][0] == "de"
-    results = lang_detector(
-        "Dieser Satz ist auf Deutsch.", lang=("de", "en"), greedy=True
-    )
+    results = langdetect("Dieser Satz ist auf Deutsch.", lang=("de", "en"), greedy=True)
     assert results[0][0] == "de"
-    results = lang_detector(
+    results = langdetect(
         "Nztruedg nsüplke deutsches weiter bgfnki gtrpinadsc.",
         lang=("de", "en"),
         greedy=False,
     )
     assert results == [("de", 0.4), ("en", 0.0), ("unk", 0.6)]
 
-    assert lang_detector(
+    assert langdetect(
         '"Exoplaneta, též extrasolární planeta, je planeta obíhající kolem jiné hvězdy než kolem Slunce."',
         lang=("cs", "sk"),
     ) == [("cs", 0.75), ("sk", 0.125), ("unk", 0.25)]
 
-    assert lang_detector(
+    assert langdetect(
         '"Moderní studie narazily na několik tajemství." Extracted from Wikipedia.',
         lang=("cs", "en"),
         token_samplers=[CustomTokenSampler(6)],

--- a/tests/test_token_sampler.py
+++ b/tests/test_token_sampler.py
@@ -1,13 +1,13 @@
 from typing import Iterable, List
 
 from simplemma.token_sampler import (
-    AbstractBaseTokenSampler,
+    TokenSampler,
     MostCommonTokenSampler,
     RelaxedMostCommonTokenSampler,
 )
 
 
-class CustomTokenSampler(AbstractBaseTokenSampler):
+class CustomTokenSampler(TokenSampler):
     def __init__(self, skip_tokens: int) -> None:
         super().__init__()
         self.skip_tokens: int = skip_tokens

--- a/tests/test_token_sampler.py
+++ b/tests/test_token_sampler.py
@@ -1,0 +1,36 @@
+from typing import List
+
+from simplemma.tokenizer import Tokenizer
+
+from simplemma.language_detector import TokenSampler, RELAXED_SPLIT_INPUT
+
+
+class CustomTokenSampler(TokenSampler):
+    def __init__(self, skip_tokens: int) -> None:
+        super().__init__()
+        self.skip_tokens: int = skip_tokens
+
+    def sample_tokens(self, text: str) -> List[str]:
+        return list(self.tokenizer.split_text(text))[self.skip_tokens :]
+
+
+def test_token_sampler():
+    sampler = TokenSampler()
+    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ijkl"]
+    assert sampler.sample_tokens("Abcd_E Abcde") == ["Abcd", "Abcde"]
+
+    sampler = TokenSampler(capitalized_threshold=0)
+    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
+
+    sampler = TokenSampler(capitalized_threshold=0, max_tokens=1)
+    assert sampler.sample_tokens("Efgh Efgh ijkl mn") == ["Efgh"]
+
+    relaxed = TokenSampler(
+        tokenizer=Tokenizer(splitting_regex=RELAXED_SPLIT_INPUT),
+        max_tokens=1000,
+        capitalized_threshold=0,
+    )
+    assert relaxed.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
+
+    custom = CustomTokenSampler(3)
+    assert custom.sample_tokens("ABCD Efgh ijkl mn") == []

--- a/tests/test_token_sampler.py
+++ b/tests/test_token_sampler.py
@@ -1,36 +1,34 @@
-from typing import List
+from typing import Iterable, List
 
-from simplemma.tokenizer import Tokenizer
+from simplemma.token_sampler import (
+    AbstractBaseTokenSampler,
+    MostCommonTokenSampler,
+    RelaxedMostCommonTokenSampler,
+)
 
-from simplemma.language_detector import TokenSampler, RELAXED_SPLIT_INPUT
 
-
-class CustomTokenSampler(TokenSampler):
+class CustomTokenSampler(AbstractBaseTokenSampler):
     def __init__(self, skip_tokens: int) -> None:
         super().__init__()
         self.skip_tokens: int = skip_tokens
 
-    def sample_tokens(self, text: str) -> List[str]:
-        return list(self.tokenizer.split_text(text))[self.skip_tokens :]
+    def sample_tokens(self, tokens: Iterable[str]) -> List[str]:
+        return list(tokens)[self.skip_tokens :]
 
 
 def test_token_sampler():
-    sampler = TokenSampler()
-    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ijkl"]
-    assert sampler.sample_tokens("Abcd_E Abcde") == ["Abcd", "Abcde"]
+    sampler = MostCommonTokenSampler()
+    assert sampler.sample_text("ABCD Efgh ijkl mn") == ["ijkl"]
+    assert sampler.sample_text("Abcd_E Abcde") == ["Abcd", "Abcde"]
 
-    sampler = TokenSampler(capitalized_threshold=0)
-    assert sampler.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
+    sampler = MostCommonTokenSampler(capitalized_threshold=0)
+    assert sampler.sample_text("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
 
-    sampler = TokenSampler(capitalized_threshold=0, max_tokens=1)
-    assert sampler.sample_tokens("Efgh Efgh ijkl mn") == ["Efgh"]
+    sampler = MostCommonTokenSampler(capitalized_threshold=0, sample_size=1)
+    assert sampler.sample_text("Efgh Efgh ijkl mn") == ["Efgh"]
 
-    relaxed = TokenSampler(
-        tokenizer=Tokenizer(splitting_regex=RELAXED_SPLIT_INPUT),
-        max_tokens=1000,
-        capitalized_threshold=0,
-    )
-    assert relaxed.sample_tokens("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
+    relaxed = RelaxedMostCommonTokenSampler()
+    assert relaxed.sample_text("ABCD Efgh ijkl mn") == ["ABCD", "Efgh", "ijkl"]
 
     custom = CustomTokenSampler(3)
-    assert custom.sample_tokens("ABCD Efgh ijkl mn") == []
+    assert custom.sample_text("ABCD Efgh ijkl mn") == []


### PR DESCRIPTION
Related to #60

This PR does the following:
* Wraps the `in_target_language` and `lang_detector` methods in a class
* Fix the `lang_detector` method in the class so it count unknown tokens correctly.
* Refactor the `in_target_language` method in the class to use the `lang_detector` (perfecto consistency between both results)

The second attempts to disambiguate and any other attempt that you can do have been left within the "legacy" `lang_detector` method.
Here you could also introduce your attempt with the different Sampler.

So, a user could use the class, and could do as many disambiguations as he wants while maintaining control of the process.
This class could be extended to receive a list of samplers to try in order in case of ex-aequo. Or a setting to try greedy if non-greedy search produced a tie. Or any other advance configuration.

Does this make sense?