### PR TITLE
rules: add generic substitution function

### DIFF
--- a/simplemma/rules/de.py
+++ b/simplemma/rules/de.py
@@ -84,7 +84,7 @@ GERMAN_PREFIXES = {
 }
 
 
-def fix_known_prefix_de(token: str):
+def fix_known_prefix_de(token: str) -> Optional[str]:
     prefix = next((p for p in GERMAN_PREFIXES if token.startswith(p)), None)
     if prefix is None or token[len(prefix) : len(prefix) + 2] == "zu":
         return None

--- a/simplemma/rules/fi.py
+++ b/simplemma/rules/fi.py
@@ -2,6 +2,9 @@ import re
 
 from typing import Optional
 
+from .generic import apply_rules
+
+
 DEFAULT_RULES = {
     # -minen nouns, ä/ö/y + a/o/u
     # https://en.wiktionary.org/wiki/-minen
@@ -36,9 +39,6 @@ def apply_fi(token: str, greedy: bool = False) -> Optional[str]:
     if len(token) < 10 or token[0].isupper():
         return None
 
-    for rule, substitution in DEFAULT_RULES.items():
-        if rule.search(token):
-            return rule.sub(substitution, token)
     ## others: but not yritteineen/yrite
     # if token.endswith("eineen") and token[-7] != token[-8]:
     #    return token[:-6] + "i"
@@ -46,4 +46,5 @@ def apply_fi(token: str, greedy: bool = False) -> Optional[str]:
     # äyskäisen → äyskäistä
     # if token.endswith("äisen"):
     #    return token[:-4]
-    return None
+
+    return apply_rules(token, DEFAULT_RULES)

--- a/simplemma/rules/generic.py
+++ b/simplemma/rules/generic.py
@@ -1,0 +1,9 @@
+from typing import Dict, Optional, Pattern
+
+
+def apply_rules(token: str, rules: Dict[Pattern[str], str]) -> Optional[str]:
+    for rule, substitution in rules.items():
+        candidate = rule.sub(substitution, token)
+        if candidate != token:
+            return candidate
+    return None

--- a/simplemma/rules/pl.py
+++ b/simplemma/rules/pl.py
@@ -2,6 +2,9 @@ import re
 
 from typing import Optional
 
+from .generic import apply_rules
+
+
 DEFAULT_RULES = {
     re.compile(r"(?:ościach|ościami|ościom)$"): "ość",  # removed: "ością", "ości"
     re.compile(
@@ -20,8 +23,4 @@ def apply_pl(token: str, greedy: bool = False) -> Optional[str]:
     if len(token) < 10 or token[0].isupper():
         return None
 
-    for rule, substitution in DEFAULT_RULES.items():
-        if rule.search(token):
-            return rule.sub(substitution, token)
-
-    return None
+    return apply_rules(token, DEFAULT_RULES)

--- a/simplemma/rules/ru.py
+++ b/simplemma/rules/ru.py
@@ -2,6 +2,9 @@ import re
 
 from typing import Optional
 
+from .generic import apply_rules
+
+
 RUSSIAN_PREFIXES = {
     "гидро",
     "за",
@@ -28,7 +31,7 @@ DEFAULT_RULES = {
 }
 
 
-def fix_known_prefix_ru(token: str):
+def fix_known_prefix_ru(token: str) -> Optional[str]:
     return next((p for p in RUSSIAN_PREFIXES if token.startswith(p)), None)
 
 
@@ -40,9 +43,6 @@ def apply_ru(token: str, greedy: bool = False) -> Optional[str]:
     if len(token) < 10 or token[0].isupper() or "-" in token:
         return None
 
-    for rule, substitution in DEFAULT_RULES.items():
-        if rule.search(token):
-            return rule.sub(substitution, token)
     # token = token.replace("а́", "a")
     # token = token.replace("о́", "o")
     # token = token.replace("и́", "и")
@@ -50,4 +50,5 @@ def apply_ru(token: str, greedy: bool = False) -> Optional[str]:
     #     return RUSSIAN_ENDINGS_OCTB.sub("ость", token)
     # if RUSSIAN_ENDINGS_CTBO.search(token):
     #     return RUSSIAN_ENDINGS_CTBO.sub("ство", token)
-    return None
+
+    return apply_rules(token, DEFAULT_RULES)


### PR DESCRIPTION
There was duplicate code and function type annotations were missing.

Applying the substitution first and potentially return the modified string saves time.