### PR TITLE
refactor: minimize dictionary lookups in _greedy_search

### DIFF
--- a/simplemma/lemmatizer.py
+++ b/simplemma/lemmatizer.py
@@ -65,15 +65,20 @@ def _greedy_search(
     candidate: str, datadict: Dict[str, str], steps: int = 1, distance: int = 5
 ) -> str:
     "Greedy mode: try further hops, not always a good idea."
-    i = 0
-    while candidate in datadict and (
-        len(datadict[candidate]) < len(candidate)
-        and levenshtein_dist(datadict[candidate], candidate) <= distance
-    ):
-        candidate = datadict[candidate]
-        i += 1
-        if i >= steps:
+    for _ in range(steps):
+        if candidate not in datadict:
             break
+
+        new_candidate = datadict[candidate]
+
+        if (
+            len(new_candidate) > len(candidate)
+            or levenshtein_dist(new_candidate, candidate) > distance
+        ):
+            break
+
+        candidate = new_candidate
+
     return candidate
 
 

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -97,7 +97,7 @@ def test_logic() -> None:
 
     assert (
         simplemma.lemmatizer._greedy_search("getesteten", deDict, steps=0, distance=20)
-        == "getestet"
+        == "getesteten"
     )
     assert (
         simplemma.lemmatizer._greedy_search("getesteten", deDict, steps=1, distance=20)


### PR DESCRIPTION
Small PR.

This reduces the dictionary lookups from 3 to 1 and remove the counter operations which should improve performance.
Not relevant for a single token but might make a different for a whole text.

Also, correct the logic so zero steps actually means zero.
Before zero steps was doing 1 lookup.