### PR TITLE
feat: throw on unsupported languages

### DIFF
--- a/simplemma/dictionary_factory.py
+++ b/simplemma/dictionary_factory.py
@@ -53,8 +53,7 @@ class DictionaryFactory:
         self._data = {}
         for lang in langs:
             if lang not in LANGLIST:
-                LOGGER.error("language not supported: %s", lang)
-                continue
+                raise ValueError(f"Unsupported language: {lang}")
             LOGGER.debug("loading %s", lang)
             self._data[lang] = self._load_dictionary_from_disk(lang)
         return self._data

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -76,7 +76,10 @@ def test_logic() -> None:
     """Test if certain code parts correspond to the intended logic."""
     # missing languages or faulty language codes
     dictionary_factory = DictionaryFactory()
-    dictionaries = dictionary_factory.get_dictionaries(("de", "abc", "en"))
+    with pytest.raises(ValueError):
+        dictionaries = dictionary_factory.get_dictionaries(("abc"))
+
+    dictionaries = dictionary_factory.get_dictionaries(("de", "en"))
     with pytest.raises(TypeError):
         lemmatize("test", lang=["test"])  # type: ignore[arg-type]
 


### PR DESCRIPTION
Silently ignore unsupported languages leads to incorrect usage of the library and potential error.

Stricter checks ensure correct usage and should not affect most users.