### PR TITLE
chore: remove useless logging

### DIFF
--- a/simplemma/strategies/dictionaries/dictionary_factory.py
+++ b/simplemma/strategies/dictionaries/dictionary_factory.py
@@ -10,7 +10,6 @@ Classes:
 """
 
 import lzma
-import logging
 import pickle
 import sys
 from abc import abstractmethod
@@ -24,8 +23,6 @@ if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
     from typing_extensions import Protocol
-
-LOGGER = logging.getLogger(__name__)
 
 DATA_FOLDER = str(Path(__file__).parent / "data")
 SUPPORTED_LANGUAGES = [
@@ -143,5 +140,4 @@ class DefaultDictionaryFactory(DictionaryFactory):
         """
         if lang not in SUPPORTED_LANGUAGES:
             raise ValueError(f"Unsupported language: {lang}")
-        LOGGER.debug("loading %s", lang)
         return self._load_dictionary_from_disk(lang)

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -1,13 +1,9 @@
 """Tests for Simplemma's language detection utilities."""
 
-import logging
-
 from simplemma import in_target_language, langdetect, LanguageDetector
 from simplemma.strategies import DefaultStrategy
 
 from .test_token_sampler import CustomTokenSampler
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 def test_proportion_in_each_language() -> None:

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -1,6 +1,5 @@
 """Tests for `simplemma` package."""
 
-import logging
 import pytest
 from typing import Dict
 
@@ -10,8 +9,6 @@ from simplemma.strategies import (
     DefaultStrategy,
     RaiseErrorFallbackStrategy,
 )
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 def test_custom_dictionary_factory() -> None:


### PR DESCRIPTION
This logging is totally useless for the library.
It's better removed.

I've left logging on the dictionary_pickler since I assume that you use that manually and benefit from the logs