### PR TITLE
Feat/better apporach to greedy lookups

### DIFF
--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -12,7 +12,12 @@ Functions:
 from operator import itemgetter
 from typing import Dict, List, Tuple, Union
 
-from .strategies import LemmatizationStrategy, DefaultStrategy
+from .strategies import (
+    LemmatizationStrategy,
+    DefaultStrategy,
+    DictionaryLookupStrategy,
+    GreedyDictionaryLookupStrategy,
+)
 from .token_sampler import (
     TokenSampler,
     MostCommonTokenSampler,
@@ -41,8 +46,11 @@ def in_target_language(
         float: The proportion of text in the target language(s).
     """
 
+    dictionary_lookup_strategy = (
+        GreedyDictionaryLookupStrategy() if greedy else DictionaryLookupStrategy()
+    )
     return LanguageDetector(
-        lang, token_sampler, DefaultStrategy(greedy)
+        lang, token_sampler, DefaultStrategy(dictionary_lookup_strategy)
     ).proportion_in_target_languages(text)
 
 
@@ -70,9 +78,12 @@ def langdetect(
             and their respective proportions.
     """
 
+    dictionary_lookup_strategy = (
+        GreedyDictionaryLookupStrategy() if greedy else DictionaryLookupStrategy()
+    )
     for token_sampler in token_samplers:
         results = LanguageDetector(
-            lang, token_sampler, DefaultStrategy(greedy)
+            lang, token_sampler, DefaultStrategy(dictionary_lookup_strategy)
         ).proportion_in_each_language(text)
 
         # post-processing

--- a/simplemma/lemmatizer.py
+++ b/simplemma/lemmatizer.py
@@ -19,6 +19,7 @@ from .strategies import (
     LemmatizationStrategy,
     DefaultStrategy,
     DictionaryLookupStrategy,
+    GreedyDictionaryLookupStrategy,
     LemmatizationFallbackStrategy,
     ToLowercaseFallbackStrategy,
 )
@@ -75,8 +76,11 @@ def lemmatize(
     Returns:
         str: The lemmatized form of the token.
     """
+    dictionary_lookup_strategy = (
+        GreedyDictionaryLookupStrategy() if greedy else DictionaryLookupStrategy()
+    )
     return Lemmatizer(
-        lemmatization_strategy=DefaultStrategy(greedy),
+        lemmatization_strategy=DefaultStrategy(dictionary_lookup_strategy),
     ).lemmatize(token, lang)
 
 
@@ -126,9 +130,12 @@ def lemma_iterator(
         str: The lemmatized tokens in the text.
     """
 
+    dictionary_lookup_strategy = (
+        GreedyDictionaryLookupStrategy() if greedy else DictionaryLookupStrategy()
+    )
     return Lemmatizer(
         tokenizer=tokenizer,
-        lemmatization_strategy=DefaultStrategy(greedy),
+        lemmatization_strategy=DefaultStrategy(dictionary_lookup_strategy),
     ).get_lemmas_in_text(text, lang)
 
 

--- a/simplemma/strategies/affix_decomposition.py
+++ b/simplemma/strategies/affix_decomposition.py
@@ -38,12 +38,8 @@ class AffixDecompositionStrategy(LemmatizationStrategy):
     to suffix decomposition if affix decomposition fails.
 
     Args:
-        greedy (bool): Flag indicating whether to use a greedy approach for decomposition.
         dictionary_lookup (DictionaryLookupStrategy, optional): The dictionary lookup strategy
             to use for retrieving lemma information. Defaults to `DictionaryLookupStrategy()`.
-        greedy_dictionary_lookup (GreedyDictionaryLookupStrategy, optional): The greedy dictionary
-            lookup strategy to use for retrieving lemma information in the greedy approach.
-            Defaults to `GreedyDictionaryLookupStrategy()`.
 
     Methods:
     - `get_lemma`: Get the lemma for a given token and language by performing subword decomposition.
@@ -53,23 +49,16 @@ class AffixDecompositionStrategy(LemmatizationStrategy):
 
     def __init__(
         self,
-        greedy: bool,
         dictionary_lookup: DictionaryLookupStrategy = DictionaryLookupStrategy(),
-        greedy_dictionary_lookup: GreedyDictionaryLookupStrategy = GreedyDictionaryLookupStrategy(),
     ):
         """
         Initialize the Affix Decomposition Strategy.
 
         Args:
-            greedy (bool): Flag indicating whether to use greedy decomposition.
             dictionary_lookup (DictionaryLookupStrategy): The dictionary lookup strategy to use.
                 Defaults to `DictionaryLookupStrategy()`.
-            greedy_dictionary_lookup (GreedyDictionaryLookupStrategy): The greedy dictionary lookup strategy to use.
-                Defaults to `GreedyDictionaryLookupStrategy()`.
         """
-        self._greedy = greedy
         self._dictionary_lookup = dictionary_lookup
-        self._greedy_dictionary_lookup = greedy_dictionary_lookup
 
     def get_lemma(self, token: str, lang: str) -> Optional[str]:
         """
@@ -83,7 +72,7 @@ class AffixDecompositionStrategy(LemmatizationStrategy):
             Optional[str]: The lemma of the token if found, or None otherwise.
         """
         limit = 6 if lang in SHORTER_GREEDY else 8
-        if (not self._greedy and not lang in AFFIX_LANGS) or len(token) <= limit:
+        if len(token) <= limit and not lang in AFFIX_LANGS:
             return None
 
         # define parameters
@@ -133,11 +122,6 @@ class AffixDecompositionStrategy(LemmatizationStrategy):
                 if lempart2 is None:
                     continue
                 # candidate must be shorter
-                # try other case
-                candidate = self._greedy_dictionary_lookup.get_lemma(part2, lang)
-                # shorten the second known part of the token
-                if candidate is not None and len(candidate) < len(part2):
-                    return part1 + candidate.lower()
                 # backup: equal length or further candidates accepted
                 # try without capitalizing
                 # even greedier

--- a/simplemma/strategies/default.py
+++ b/simplemma/strategies/default.py
@@ -15,7 +15,6 @@ Class:
 
 from typing import Optional
 
-from .dictionaries.dictionary_factory import DictionaryFactory, DefaultDictionaryFactory
 from .lemmatization_strategy import LemmatizationStrategy
 from .dictionary_lookup import DictionaryLookupStrategy
 from .hyphen_removal import HyphenRemovalStrategy
@@ -37,7 +36,6 @@ class DefaultStrategy(LemmatizationStrategy):
     - `_hyphen_search` (HyphenRemovalStrategy): A strategy for lemmatization by removing hyphens.
     - `_rules_search` (RulesStrategy): A strategy for rule-based lemmatization.
     - `_prefix_search` (PrefixDecompositionStrategy): A strategy for lemmatization by prefix decomposition.
-    - `_greedy_dictionary_lookup` (Optional[GreedyDictionaryLookupStrategy]): A strategy for dictionary lookup with a greedy approach.
     - `_affix_search` (AffixDecompositionStrategy): A strategy for lemmatization by affix decomposition.
 
     Methods:
@@ -55,23 +53,17 @@ class DefaultStrategy(LemmatizationStrategy):
 
     def __init__(
         self,
-        greedy: bool = False,
-        dictionary_factory: DictionaryFactory = DefaultDictionaryFactory(),
+        dictionary_lookup: DictionaryLookupStrategy = DictionaryLookupStrategy(),
     ):
         """
         Initialize the Default Strategy.
 
         Args:
-        - `greedy` (bool): Whether to use a greedy approach for dictionary lookup. Defaults to `False`.
-        - `dictionary_factory` (DictionaryFactory): A factory for creating dictionaries.
-            Defaults to `DefaultDictionaryFactory()`.
+            dictionary_lookup (DictionaryLookupStrategy, optional): The dictionary lookup strategy
+                to use for retrieving lemma information. Defaults to `DictionaryLookupStrategy()`.
 
         """
-        self._dictionary_lookup = (
-            GreedyDictionaryLookupStrategy(dictionary_factory)
-            if greedy
-            else DictionaryLookupStrategy(dictionary_factory)
-        )
+        self._dictionary_lookup = dictionary_lookup
         self._hyphen_search = HyphenRemovalStrategy(self._dictionary_lookup)
         self._rules_search = RulesStrategy()
         self._prefix_search = PrefixDecompositionStrategy(

--- a/simplemma/strategies/default.py
+++ b/simplemma/strategies/default.py
@@ -50,7 +50,6 @@ class DefaultStrategy(LemmatizationStrategy):
         "_hyphen_search",
         "_rules_search",
         "_prefix_search",
-        "_greedy_dictionary_lookup",
         "_affix_search",
     ]
 
@@ -68,19 +67,17 @@ class DefaultStrategy(LemmatizationStrategy):
             Defaults to `DefaultDictionaryFactory()`.
 
         """
-        self._greedy = greedy
-        self._dictionary_lookup = DictionaryLookupStrategy(dictionary_factory)
+        self._dictionary_lookup = (
+            GreedyDictionaryLookupStrategy(dictionary_factory)
+            if greedy
+            else DictionaryLookupStrategy(dictionary_factory)
+        )
         self._hyphen_search = HyphenRemovalStrategy(self._dictionary_lookup)
         self._rules_search = RulesStrategy()
         self._prefix_search = PrefixDecompositionStrategy(
             dictionary_lookup=self._dictionary_lookup
         )
-        greedy_dictionary_lookup = GreedyDictionaryLookupStrategy(dictionary_factory)
-        self._affix_search = AffixDecompositionStrategy(
-            greedy, self._dictionary_lookup, greedy_dictionary_lookup
-        )
-
-        self._greedy_dictionary_lookup = greedy_dictionary_lookup if greedy else None
+        self._affix_search = AffixDecompositionStrategy(self._dictionary_lookup)
 
     def get_lemma(self, token: str, lang: str) -> Optional[str]:
         """
@@ -98,7 +95,7 @@ class DefaultStrategy(LemmatizationStrategy):
         if token.isnumeric():
             return token
 
-        candidate = (
+        return (
             # supervised searches
             self._dictionary_lookup.get_lemma(token, lang)
             or self._hyphen_search.get_lemma(token, lang)
@@ -107,9 +104,3 @@ class DefaultStrategy(LemmatizationStrategy):
             # weakly supervised / greedier searches
             or self._affix_search.get_lemma(token, lang)
         )
-
-        # additional round
-        if candidate is not None and self._greedy_dictionary_lookup is not None:
-            candidate = self._greedy_dictionary_lookup.get_lemma(candidate, lang)
-
-        return candidate

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -29,7 +29,7 @@ def test_search() -> None:
         GreedyDictionaryLookupStrategy(steps=0, distance=20).get_lemma(
             "getesteten", "de"
         )
-        == "getesteten"
+        == "getestet"
     )
     assert (
         GreedyDictionaryLookupStrategy(steps=1, distance=20).get_lemma(
@@ -41,13 +41,13 @@ def test_search() -> None:
         GreedyDictionaryLookupStrategy(steps=2, distance=20).get_lemma(
             "getesteten", "de"
         )
-        == "testen"
+        == "getestet"
     )
     assert (
-        GreedyDictionaryLookupStrategy(steps=2, distance=2).get_lemma(
+        GreedyDictionaryLookupStrategy(steps=3, distance=2).get_lemma(
             "getesteten", "de"
         )
         == "getestet"
     )
 
-    assert AffixDecompositionStrategy(greedy=True).get_lemma("ccc", "de") is None
+    assert AffixDecompositionStrategy().get_lemma("ccc", "de") is None

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -3,7 +3,7 @@
 import logging
 
 from simplemma import in_target_language, langdetect, LanguageDetector
-from simplemma.strategies import DefaultStrategy
+from simplemma.strategies import DefaultStrategy, GreedyDictionaryLookupStrategy
 
 from .test_token_sampler import CustomTokenSampler
 
@@ -13,13 +13,14 @@ logging.basicConfig(level=logging.DEBUG)
 def test_proportion_in_each_language() -> None:
     # sanity checks
     assert LanguageDetector(
-        lang=("de", "en"), lemmatization_strategy=DefaultStrategy(greedy=True)
+        lang=("de", "en"),
+        lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy()),
     ).proportion_in_each_language(" aa ") == {"unk": 1}
     assert langdetect(" aa ", lang=("de", "en"), greedy=True) == [("unk", 1)]
 
     text = "Test test"
     assert LanguageDetector(
-        lang=("de", "en"), lemmatization_strategy=DefaultStrategy(greedy=False)
+        lang=("de", "en"), lemmatization_strategy=DefaultStrategy()
     ).proportion_in_each_language(text) == {"de": 1.0, "en": 1.0, "unk": 0.0}
     assert langdetect(text, lang=("de", "en"), greedy=False) == [
         ("de", 1.0),
@@ -27,7 +28,8 @@ def test_proportion_in_each_language() -> None:
         ("unk", 0.0),
     ]
     assert LanguageDetector(
-        lang=("de", "en"), lemmatization_strategy=DefaultStrategy(greedy=True)
+        lang=("de", "en"),
+        lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy()),
     ).proportion_in_each_language(text) == {"de": 1.0, "en": 1.0, "unk": 0.0}
     assert langdetect(text, lang=("de", "en"), greedy=True) == [
         ("de", 1.0),
@@ -38,7 +40,7 @@ def test_proportion_in_each_language() -> None:
     lang = ("de", "en")
     text = "Nztruedg nsüplke deutsches weiter bgfnki gtrpinadsc."
     assert LanguageDetector(
-        lang=lang, lemmatization_strategy=DefaultStrategy(greedy=False)
+        lang=lang, lemmatization_strategy=DefaultStrategy()
     ).proportion_in_each_language(text) == {
         "de": 0.4,
         "en": 0.0,
@@ -118,7 +120,7 @@ def test_main_language():
     lang = ("de", "en")
     assert (
         LanguageDetector(
-            lang=lang, lemmatization_strategy=DefaultStrategy(greedy=False)
+            lang=lang, lemmatization_strategy=DefaultStrategy()
         ).main_language(text)
         == langdetect(text, lang=lang, greedy=False)[0][0]
         == "de"
@@ -126,7 +128,8 @@ def test_main_language():
 
     assert (
         LanguageDetector(
-            lang=lang, lemmatization_strategy=DefaultStrategy(greedy=True)
+            lang=lang,
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy()),
         ).main_language(text)
         == langdetect(text, lang=lang, greedy=False)[0][0]
         == "de"

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -72,17 +72,17 @@ def test_readme() -> None:
     assert (
         Lemmatizer().lemmatize("spaghettis", lang="it")
         == lemmatize("spaghettis", lang="it")
-        == "spaghettis"
+        == "spaghetto"
     )
     assert (
         Lemmatizer().lemmatize("spaghettini", lang="it")
         == lemmatize("spaghettini", lang="it")
-        == "spaghettini"
+        == "spaghetto"
     )
     assert (
         Lemmatizer().lemmatize("spaghettis", lang=("it", "fr"))
         == lemmatize("spaghettis", lang=("it", "fr"))
-        == "spaghetti"
+        == "spaghetto"
     )
     assert (
         Lemmatizer().lemmatize("spaghetti", lang=("it", "fr"))
@@ -174,7 +174,7 @@ def test_subwords() -> None:
             myword, lang="de"
         )
         == lemmatize(myword, lang="de", greedy=False)
-        == "Impftermine"
+        == "Impftermin"
     )
     assert (
         Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
@@ -204,7 +204,7 @@ def test_subwords() -> None:
             myword, lang="de"
         )
         == lemmatize(myword, lang="de", greedy=False)
-        == "Hoffnungsmaschinen"
+        == "Hoffnungsmaschine"
     )
     assert (
         Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
@@ -286,7 +286,7 @@ def test_subwords() -> None:
     )
     assert (
         lemmatize("insulinproduzierende", lang="de", greedy=True)
-        == "insulinproduzierend"
+        == "insulinproduzieren"
     )
     # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("Urlaubsreisenden", lang="de") == lemmatize("Urlaubsreisenden", lang="de", greedy=True) == "Urlaubsreisende"
     assert (

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -8,6 +8,8 @@ from simplemma import lemmatize, is_known, text_lemmatizer, lemma_iterator, Lemm
 from simplemma.strategies import (
     DictionaryFactory,
     DefaultStrategy,
+    DictionaryLookupStrategy,
+    GreedyDictionaryLookupStrategy,
     RaiseErrorFallbackStrategy,
 )
 
@@ -25,7 +27,7 @@ def test_custom_dictionary_factory() -> None:
     assert (
         Lemmatizer(
             lemmatization_strategy=DefaultStrategy(
-                dictionary_factory=CustomDictionaryFactory()
+                DictionaryLookupStrategy(CustomDictionaryFactory())
             )
         ).lemmatize("testing", lang="en")
         == "the test works!!"
@@ -49,16 +51,16 @@ def test_readme() -> None:
     ]
     # greediness
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=False)).lemmatize(
+        Lemmatizer(lemmatization_strategy=DefaultStrategy()).lemmatize(
             "angekündigten", lang="de"
         )
         == lemmatize("angekündigten", lang="de", greedy=False)
         == "angekündigt"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "angekündigten", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("angekündigten", lang="de")
         == lemmatize("angekündigten", lang="de", greedy=True)
         == "ankündigen"
     )
@@ -90,9 +92,9 @@ def test_readme() -> None:
         == "spaghetto"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "spaghettis", lang=("it", "fr")
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("spaghettis", lang=("it", "fr"))
         == lemmatize("spaghettis", lang=("it", "fr"), greedy=True)
         == "spaghetto"
     )
@@ -147,104 +149,104 @@ def test_exceptions() -> None:
 def test_subwords() -> None:
     """Test recognition and conversion of subword units."""
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "OBI", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("OBI", lang="de")
         == lemmatize("OBI", lang="de", greedy=True)
         == "OBI"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=False)).lemmatize(
+        Lemmatizer(lemmatization_strategy=DefaultStrategy()).lemmatize(
             "mRNA-Impfstoffe", lang="de"
         )
         == lemmatize("mRNA-Impfstoffe", lang="de", greedy=False)
         == "mRNA-Impfstoff"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "mRNA-impfstoffe", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("mRNA-impfstoffe", lang="de")
         == lemmatize("mRNA-impfstoffe", lang="de", greedy=True)
         == "mRNA-Impfstoff"
     )
     # greedy subword
     myword = "Impftermine"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=False)).lemmatize(
+        Lemmatizer(lemmatization_strategy=DefaultStrategy()).lemmatize(
             myword, lang="de"
         )
         == lemmatize(myword, lang="de", greedy=False)
         == "Impftermin"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            myword, lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize(myword, lang="de")
         == lemmatize(myword, lang="de", greedy=True)
         == "Impftermin"
     )
     myword = "Impfbeginn"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=False)).lemmatize(
+        Lemmatizer(lemmatization_strategy=DefaultStrategy()).lemmatize(
             myword, lang="de"
         )
         == lemmatize(myword, lang="de", greedy=False)
         == "Impfbeginn"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            myword, lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize(myword, lang="de")
         == lemmatize(myword, lang="de", greedy=True)
         == "Impfbeginn"
     )
     myword = "Hoffnungsmaschinen"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=False)).lemmatize(
+        Lemmatizer(lemmatization_strategy=DefaultStrategy()).lemmatize(
             myword, lang="de"
         )
         == lemmatize(myword, lang="de", greedy=False)
         == "Hoffnungsmaschine"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            myword, lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize(myword, lang="de")
         == lemmatize(myword, lang="de", greedy=True)
         == "Hoffnungsmaschine"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "börsennotierter", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("börsennotierter", lang="de")
         == lemmatize("börsennotierter", lang="de", greedy=True)
         == "börsennotiert"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "journalistischer", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("journalistischer", lang="de")
         == lemmatize("journalistischer", lang="de", greedy=True)
         == "journalistisch"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Delegiertenstimmen", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Delegiertenstimmen", lang="de")
         == lemmatize("Delegiertenstimmen", lang="de", greedy=True)
         == "Delegiertenstimme"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Koalitionskreisen", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Koalitionskreisen", lang="de")
         == lemmatize("Koalitionskreisen", lang="de", greedy=True)
         == "Koalitionskreis"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Infektionsfälle", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Infektionsfälle", lang="de")
         == lemmatize("Infektionsfälle", lang="de", greedy=True)
         == "Infektionsfall"
     )
@@ -253,23 +255,23 @@ def test_subwords() -> None:
         == "Corona-Einsatzstab"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Clearinghäusern", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Clearinghäusern", lang="de")
         == lemmatize("Clearinghäusern", lang="de", greedy=True)
         == "Clearinghaus"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Mittelstreckenjets", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Mittelstreckenjets", lang="de")
         == lemmatize("Mittelstreckenjets", lang="de", greedy=True)
         == "Mittelstreckenjet"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Länderministerien", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Länderministerien", lang="de")
         == lemmatize("Länderministerien", lang="de", greedy=True)
         == "Länderministerium"
     )
@@ -278,9 +280,9 @@ def test_subwords() -> None:
         == "Gesundheitsschutzkontrolle"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Nachkriegsjuristen", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Nachkriegsjuristen", lang="de")
         == lemmatize("Nachkriegsjuristen", lang="de", greedy=True)
         == "Nachkriegsjurist"
     )
@@ -288,11 +290,11 @@ def test_subwords() -> None:
         lemmatize("insulinproduzierende", lang="de", greedy=True)
         == "insulinproduzieren"
     )
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("Urlaubsreisenden", lang="de") == lemmatize("Urlaubsreisenden", lang="de", greedy=True) == "Urlaubsreisende"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("Urlaubsreisenden", lang="de") == lemmatize("Urlaubsreisenden", lang="de", greedy=True) == "Urlaubsreisende"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Grünenvorsitzende", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Grünenvorsitzende", lang="de")
         == lemmatize("Grünenvorsitzende", lang="de", greedy=True)
         == "Grünenvorsitzende"
     )
@@ -301,16 +303,16 @@ def test_subwords() -> None:
         == "Qualifikationsrunde"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "krisensichere", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("krisensichere", lang="de")
         == lemmatize("krisensichere", lang="de", greedy=True)
         == "krisensicher"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "ironischerweise", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("ironischerweise", lang="de")
         == lemmatize("ironischerweise", lang="de", greedy=True)
         == "ironischerweise"
     )
@@ -319,38 +321,38 @@ def test_subwords() -> None:
         == "Landespressedienst"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Lehrerverbänden", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Lehrerverbänden", lang="de")
         == lemmatize("Lehrerverbänden", lang="de", greedy=True)
         == "Lehrerverband"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Terminvergaberunden", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Terminvergaberunden", lang="de")
         == lemmatize("Terminvergaberunden", lang="de", greedy=True)
         == "Terminvergaberunde"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Gen-Sequenzierungen", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Gen-Sequenzierungen", lang="de")
         == lemmatize("Gen-Sequenzierungen", lang="de", greedy=True)
         == "Gen-Sequenzierung"
     )
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("wiederverwendbaren", lang="de") == lemmatize("wiederverwendbaren", lang="de", greedy=True) == "wiederverwendbar"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("wiederverwendbaren", lang="de") == lemmatize("wiederverwendbaren", lang="de", greedy=True) == "wiederverwendbar"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Spitzenposten", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Spitzenposten", lang="de")
         == lemmatize("Spitzenposten", lang="de", greedy=True)
         == "Spitzenposten"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "I-Pace", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("I-Pace", lang="de")
         == lemmatize("I-Pace", lang="de", greedy=True)
         == "I-Pace"
     )
@@ -362,33 +364,33 @@ def test_subwords() -> None:
     #    lemmatize("standortübergreifend", lang="de", greedy=True)
     #    == "standortübergreifend"
     # )
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("obamamäßigsten", lang="de") == lemmatize("obamamäßigsten", lang="de", greedy=True) == "obamamäßig"
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("obamaartigere", lang="de") == lemmatize("obamaartigere", lang="de", greedy=True) == "obamaartig"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("obamamäßigsten", lang="de") == lemmatize("obamamäßigsten", lang="de", greedy=True) == "obamamäßig"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("obamaartigere", lang="de") == lemmatize("obamaartigere", lang="de", greedy=True) == "obamaartig"
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "durchgestyltes", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("durchgestyltes", lang="de")
         == lemmatize("durchgestyltes", lang="de", greedy=True)
         == "durchgestylt"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "durchgeknallte", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("durchgeknallte", lang="de")
         == lemmatize("durchgeknallte", lang="de", greedy=True)
         == "durchgeknallt"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "herunterfährt", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("herunterfährt", lang="de")
         == lemmatize("herunterfährt", lang="de", greedy=True)
         == "herunterfahren"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Atomdeals", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Atomdeals", lang="de")
         == lemmatize("Atomdeals", lang="de", greedy=True)
         == "Atomdeal"
     )
@@ -401,35 +403,35 @@ def test_subwords() -> None:
     #    == "Bürgerschaftsabgeordnete"
     # )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Lichtbild-Ausweis", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Lichtbild-Ausweis", lang="de")
         == lemmatize("Lichtbild-Ausweis", lang="de", greedy=True)
         == "Lichtbildausweis"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Kapuzenpullis", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Kapuzenpullis", lang="de")
         == lemmatize("Kapuzenpullis", lang="de", greedy=True)
         == "Kapuzenpulli"
     )
     assert (
-        Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize(
-            "Pharmagrößen", lang="de"
-        )
+        Lemmatizer(
+            lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
+        ).lemmatize("Pharmagrößen", lang="de")
         == lemmatize("Pharmagrößen", lang="de", greedy=True)
         == "Pharmagröße"
     )
 
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("beständigsten", lang="de") == lemmatize("beständigsten", lang="de", greedy=True) == "beständig"
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('zweitstärkster', lang='de') == lemmatize('zweitstärkster', lang='de', greedy=True) == 'zweitstärkste'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('Abholservices', lang='de') == lemmatize('Abholservices', lang='de', greedy=True) == 'Abholservice'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('Funktionärsebene', lang='de') == lemmatize('Funktionärsebene', lang='de', greedy=True) == 'Funktionärsebene'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('strafbewehrte', lang='de') == lemmatize('strafbewehrte', lang='de', greedy=True) == 'strafbewehrt'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('fälschungssicheren', lang='de') == lemmatize('fälschungssicheren', lang='de', greedy=True) == 'fälschungssicher'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize('Spargelstangen', lang='de') == lemmatize('Spargelstangen', lang='de', greedy=True) == 'Spargelstange'
-    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(greedy=True)).lemmatize("Bandmitgliedern", lang="de") == lemmatize("Bandmitgliedern", lang="de", greedy=True) == "Bandmitglied"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("beständigsten", lang="de") == lemmatize("beständigsten", lang="de", greedy=True) == "beständig"
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('zweitstärkster', lang='de') == lemmatize('zweitstärkster', lang='de', greedy=True) == 'zweitstärkste'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('Abholservices', lang='de') == lemmatize('Abholservices', lang='de', greedy=True) == 'Abholservice'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('Funktionärsebene', lang='de') == lemmatize('Funktionärsebene', lang='de', greedy=True) == 'Funktionärsebene'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('strafbewehrte', lang='de') == lemmatize('strafbewehrte', lang='de', greedy=True) == 'strafbewehrt'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('fälschungssicheren', lang='de') == lemmatize('fälschungssicheren', lang='de', greedy=True) == 'fälschungssicher'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize('Spargelstangen', lang='de') == lemmatize('Spargelstangen', lang='de', greedy=True) == 'Spargelstange'
+    # assert Lemmatizer(lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())).lemmatize("Bandmitgliedern", lang="de") == lemmatize("Bandmitgliedern", lang="de", greedy=True) == "Bandmitglied"
 
     # prefixes
     assert (
@@ -483,9 +485,9 @@ def test_get_lemmas_in_text() -> None:
     text = "Nous déciderons une fois arrivées. Voilà."
     assert (
         list(
-            Lemmatizer(
-                lemmatization_strategy=DefaultStrategy(greedy=False)
-            ).get_lemmas_in_text(text, lang="fr")
+            Lemmatizer(lemmatization_strategy=DefaultStrategy()).get_lemmas_in_text(
+                text, lang="fr"
+            )
         )
         == text_lemmatizer(text, lang="fr", greedy=False)
         == [
@@ -502,9 +504,9 @@ def test_get_lemmas_in_text() -> None:
     text = "Nous déciderons une fois arrivées. Voilà."
     assert (
         list(
-            Lemmatizer(
-                lemmatization_strategy=DefaultStrategy(greedy=False)
-            ).get_lemmas_in_text(text, lang="fr")
+            Lemmatizer(lemmatization_strategy=DefaultStrategy()).get_lemmas_in_text(
+                text, lang="fr"
+            )
         )
         == list(lemma_iterator(text, lang="fr", greedy=False))
         == text_lemmatizer(text, lang="fr", greedy=False)
@@ -512,9 +514,9 @@ def test_get_lemmas_in_text() -> None:
     text = "Pepa e Iván son una pareja sentimental, ambos dedicados al doblaje de películas."
     assert (
         list(
-            Lemmatizer(
-                lemmatization_strategy=DefaultStrategy(greedy=False)
-            ).get_lemmas_in_text(text, lang="es")
+            Lemmatizer(lemmatization_strategy=DefaultStrategy()).get_lemmas_in_text(
+                text, lang="es"
+            )
         )
         == text_lemmatizer(text, lang="es", greedy=False)
         == [
@@ -538,7 +540,7 @@ def test_get_lemmas_in_text() -> None:
     assert (
         list(
             Lemmatizer(
-                lemmatization_strategy=DefaultStrategy(greedy=True)
+                lemmatization_strategy=DefaultStrategy(GreedyDictionaryLookupStrategy())
             ).get_lemmas_in_text(text, lang="es")
         )
         == text_lemmatizer(text, lang="es", greedy=True)

--- a/training/eval/udscore.py
+++ b/training/eval/udscore.py
@@ -7,7 +7,11 @@ from os import makedirs, path
 from conllu import parse_incr  # type: ignore
 from simplemma import Lemmatizer
 from simplemma.strategies.dictionaries import DefaultDictionaryFactory
-from simplemma.strategies.default import DefaultStrategy
+from simplemma.strategies.default import (
+    DefaultStrategy,
+    DictionaryLookupStrategy,
+    GreedyDictionaryLookupStrategy,
+)
 
 if not path.exists("csv"):
     makedirs("csv")
@@ -69,15 +73,14 @@ for filedata in data_files:
         data_file = myfile.read()
     start = time.time()
     _dictionary_factory = DefaultDictionaryFactory()
-    strategies = DefaultStrategy(greedy=False)
     lemmatizer = Lemmatizer(
         lemmatization_strategy=DefaultStrategy(
-            greedy=False, dictionary_factory=_dictionary_factory
+            DictionaryLookupStrategy(_dictionary_factory)
         ),
     )
     greedy_lemmatizer = Lemmatizer(
         lemmatization_strategy=DefaultStrategy(
-            greedy=True, dictionary_factory=_dictionary_factory
+            GreedyDictionaryLookupStrategy(_dictionary_factory)
         ),
     )
     print("==", filedata, "==")


### PR DESCRIPTION
With discussed on another PR that the greedy lookup was used inconsistently across the different strategies.


This is my take on the problem: The default strategy receives a DictionaryLookupStrategy (greedy or not) and uses it for all the other strategies.
So, either everything is greedy or nothing is.