### PR TITLE
fix: bring back initial arg in lemmatize

### DIFF
--- a/simplemma/lemmatizer.py
+++ b/simplemma/lemmatizer.py
@@ -63,7 +63,7 @@ def is_known(
 
 
 def lemmatize(
-    token: str, lang: Union[str, Tuple[str, ...]], greedy: bool = False
+    token: str, lang: Union[str, Tuple[str, ...]], greedy: bool = False, initial: bool = False
 ) -> str:
     """Lemmatize a token in the specified language(s).
 
@@ -77,7 +77,7 @@ def lemmatize(
     """
     return Lemmatizer(
         lemmatization_strategy=DefaultStrategy(greedy),
-    ).lemmatize(token, lang)
+    ).lemmatize(token.lower() if initial else token, lang)
 
 
 def text_lemmatizer(

--- a/tests/test_lemmatizer.py
+++ b/tests/test_lemmatizer.py
@@ -557,3 +557,7 @@ def test_get_lemmas_in_text() -> None:
             ".",
         ]
     )
+
+def test_lemmatize() -> None:
+    assert (lemmatize("Dritte", "de", initial=True) == "dritt")
+    assert (lemmatize("Dritte", "de", initial=False) == "Dritter")


### PR DESCRIPTION
Closes #99.

This brings back intial.
However, I feel strongly that this doesn't belong here as it breaks the single responsibility principle..
`lemmatize` should lemmatize the given token and the decision on the capitalization is a pre-step that depends on how the tokens were obtains.

So, I would rather, keeping it as is.
The same line where you decide if `initial` is true or false, you could use to send `token` or `token.lower()`.

```python
initial = is_initial(my_word)
lemmatize(my_word, my_lang, intiial)
```
is simply

```python
lemmatize(my_word.lower() if is_initial(my_word) else my_word, my_lang)
```

It works the same and it keeps each responsibility where is belongs.

But, at the end of the day, it is your call 🙂 