### PR TITLE
docs: add mkdocs page for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,6 @@ ENV/
 simplemma/lists/
 
 # Not ready yet
-docs/
 AUTHORS.rst
 CONTRIBUTING.rst
 Makefile

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,39 @@
+## Contributions
+
+### Issues, bugs & improvment ideas
+
+Feel free to contribute, notably by [filing issues](https://github.com/adbar/simplemma/issues) for feedback, bug reports, or links to further lemmatization lists, rules and tests.
+
+You can also contribute to this [lemmatization list repository](https://github.com/michmech/lemmatization-lists).
+
+### Contributing to the code
+
+Pull requests are welcome.
+
+Before creating the pull request, please ensure that it pass all the quality checks:
+
+```sh
+# Install dev dependencies
+pip install -r requirements.dev.txt
+# Check code style
+black --check --diff simplemma training tests
+# Check typings
+mypy -p simplemma -p training -p tests
+# Run tests
+pytest --cov=./ --cov-report=xml
+
+```
+
+Also, if your PR changes needs documentation changes, see the next section.
+
+### Contributing to documentation
+
+```sh
+# Install dev dependencies
+pip install -r requirements.docs.txt
+# Build mkdocs
+mkdocs build
+# Check typings
+mypy -p simplemma -p training -p tests
+# Run tests
+pytest --cov=./ --cov-report=xml

--- a/docs/credit-and-licenses.md
+++ b/docs/credit-and-licenses.md
@@ -1,0 +1,12 @@
+# Credits and licenses
+
+Software under MIT license, for the linguistic information databases see ``licenses`` folder.
+
+The surface lookups (non-greedy mode) use lemmatization lists derived from various sources, ordered by relative importance:
+
+- [Lemmatization lists](https://github.com/michmech/lemmatization-lists) by Michal Měchura (Open Database License)
+- Wiktionary entries packaged by the [Kaikki project](https://kaikki.org/)
+- [FreeLing project](https://github.com/TALP-UPC/FreeLing)
+- [spaCy lookups data](https://github.com/explosion/spacy-lookups-data)
+- [Unimorph Project](https://unimorph.github.io/)
+- [Wikinflection corpus](https://github.com/lenakmeth/Wikinflection-Corpus) by Eleni Metheniti (CC BY 4.0 License)

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,0 +1,31 @@
+/* Indentation. */
+div.doc-contents:not(.first) {
+  padding-left: 25px;
+  border-left: .05rem solid var(--md-typeset-table-color);
+}
+
+/* Mark external links as such. */
+a.autorefs-external::after {
+  /* https://primer.style/octicons/arrow-up-right-24 */
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="rgb(0, 0, 0)" d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
+  content: ' ';
+
+  display: inline-block;
+  vertical-align: middle;
+  position: relative;
+  bottom: 0.1em;
+  margin-left: 0.2em;
+  margin-right: 0.1em;
+
+  height: 0.7em;
+  width: 0.7em;
+  border-radius: 100%;
+  background-color: var(--md-typeset-a-color);
+}
+a.autorefs-external:hover::after {
+  background-color: var(--md-accent-fg-color);
+}
+
+h5.doc-heading {
+  font-size: 1em;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+# Introduction
+
+## Purpose
+
+[Lemmatization](https://en.wikipedia.org/wiki/Lemmatisation) is the process of grouping together the inflected forms of a word so they can be analysed as a single item, identified by the word's lemma, or dictionary form. Unlike stemming, lemmatization outputs word units that are still valid linguistic forms.
+
+In modern natural language processing (NLP), this task is often indirectly tackled by more complex systems encompassing a whole processing pipeline. However, it appears that there is no straightforward way to address lemmatization in Python although this task can be crucial in fields such as information retrieval and NLP.
+
+**Simplemma** provides a simple and multilingual approach to look for base forms or lemmata. It may not be as powerful as full-fledged solutions but it is generic, easy to install and straightforward to use. In particular, it does not need morphosyntactic information and can process a raw series of tokens or even a text with its built-in tokenizer. By design it should be reasonably fast and work in a large majority of cases, without being perfect.
+
+With its comparatively small footprint it is especially useful when speed and simplicity matter, in low-resource contexts, for educational purposes, or as a baseline system for lemmatization and morphological analysis.
+
+Currently, 48 languages are partly or fully supported (see table below).
+
+
+## Installation
+
+The current library is written in pure Python with no dependencies:
+
+`pip install simplemma`
+
+- `pip3` where applicable
+- `pip install -U simplemma` for updates
+
+
+## Usage
+
+
+### Word-by-word
+
+
+Simplemma is used by selecting a language of interest and then applying the data on a list of words.
+
+```python
+    >>> import simplemma
+    # get a word
+    myword = 'masks'
+    # decide which language to use and apply it on a word form
+    >>> simplemma.lemmatize(myword, lang='en')
+    'mask'
+    # grab a list of tokens
+    >>> mytokens = ['Hier', 'sind', 'Vaccines']
+    >>> for token in mytokens:
+    >>>     simplemma.lemmatize(token, lang='de')
+    'hier'
+    'sein'
+    'Vaccines'
+    # list comprehensions can be faster
+    >>> [simplemma.lemmatize(t, lang='de') for t in mytokens]
+    ['hier', 'sein', 'Vaccines']
+```

--- a/docs/reference/language_detector.md
+++ b/docs/reference/language_detector.md
@@ -1,0 +1,1 @@
+::: simplemma.language_detector

--- a/docs/reference/lemmatizer.md
+++ b/docs/reference/lemmatizer.md
@@ -1,0 +1,1 @@
+::: simplemma.lemmatizer

--- a/docs/reference/strategies/affix_decomposition.md
+++ b/docs/reference/strategies/affix_decomposition.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.affix_decomposition

--- a/docs/reference/strategies/default.md
+++ b/docs/reference/strategies/default.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.default

--- a/docs/reference/strategies/dictionaries/dictionary_factory.md
+++ b/docs/reference/strategies/dictionaries/dictionary_factory.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.dictionaries.dictionary_factory

--- a/docs/reference/strategies/dictionary_lookup.md
+++ b/docs/reference/strategies/dictionary_lookup.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.dictionary_lookup

--- a/docs/reference/strategies/fallback/lemmatization_fallback_strategy.md
+++ b/docs/reference/strategies/fallback/lemmatization_fallback_strategy.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.fallback.lemmatization_fallback_strategy

--- a/docs/reference/strategies/fallback/raise_error.md
+++ b/docs/reference/strategies/fallback/raise_error.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.fallback.raise_error

--- a/docs/reference/strategies/fallback/to_lowercase.md
+++ b/docs/reference/strategies/fallback/to_lowercase.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.fallback.to_lowercase

--- a/docs/reference/strategies/greedy_dictionary_lookup.md
+++ b/docs/reference/strategies/greedy_dictionary_lookup.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.greedy_dictionary_lookup

--- a/docs/reference/strategies/hyphen_removal.md
+++ b/docs/reference/strategies/hyphen_removal.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.hyphen_removal

--- a/docs/reference/strategies/lemmatization_strategy.md
+++ b/docs/reference/strategies/lemmatization_strategy.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.lemmatization_strategy

--- a/docs/reference/strategies/prefix_decomposition.md
+++ b/docs/reference/strategies/prefix_decomposition.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.prefix_decomposition

--- a/docs/reference/strategies/rules.md
+++ b/docs/reference/strategies/rules.md
@@ -1,0 +1,1 @@
+::: simplemma.strategies.rules

--- a/docs/reference/token_sampler.md
+++ b/docs/reference/token_sampler.md
@@ -1,0 +1,1 @@
+::: simplemma.token_sampler

--- a/docs/reference/tokenizer.md
+++ b/docs/reference/tokenizer.md
@@ -1,0 +1,1 @@
+::: simplemma.tokenizer

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -1,0 +1,1 @@
+::: simplemma.utils

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -1,0 +1,66 @@
+# Supported languages
+
+The following languages are available using their [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes):
+
+## Available languages (2022-09-05)
+
+Code    | Language             | Forms (10³) |Acc.  | Comments
+------- | -------------------- | ----------- |----- | ------------------------------------------------------------------------
+``bg``  | Bulgarian            | 213         |      |
+``ca``  | Catalan              | 579         |      |
+``cs``  | Czech                | 187         |0.88  | on UD CS-PDT
+``cy``  | Welsh                | 360         || 
+``da``  | Danish               | 554         |0.92  | on UD DA-DDT, alternative: [lemmy](https://github.com/sorenlind/lemmy)
+``de``  | German               | 682         |0.95  | on UD DE-GSD, see also [German-NLP list](https://github.com/adbar/German-NLP#Lemmatization)
+``el``  | Greek                | 183         |0.88  | on UD EL-GDT
+``en``  | English              | 136         |0.94  | on UD EN-GUM, alternative: [LemmInflect](https://github.com/bjascob/LemmInflect)
+``enm`` | Middle English       | 38          |      |
+``es``  | Spanish              | 720         |0.94  | on UD ES-GSD
+``et``  | Estonian             | 133         |      | low coverage
+``fa``  | Persian              | 10          |      | experimental
+``fi``  | Finnish              | 2,106       |      | evaluation and alternatives: see [this benchmark](https://github.com/aajanki/finnish-pos-accuracy)
+``fr``  | French               | 217         |0.94  | on UD FR-GSD
+``ga``  | Irish                | 383         |      |
+``gd``  | Gaelic               | 48          |      |
+``gl``  | Galician             | 384         |      |
+``gv``  | Manx                 | 62          |      |
+``hbs`` | Serbo-Croatian       | 838         |      | Croatian and Serbian lists to be added later
+``hi``  | Hindi                | 58          |      | experimental
+``hu``  | Hungarian            | 458         |      |
+``hy``  | Armenian             | 323         |      |
+``id``  | Indonesian           | 17          |0.91  | on UD ID-CSUI
+``is``  | Icelandic            | 175         |      |
+``it``  | Italian              | 333         |0.93  | on UD IT-ISDT
+``ka``  | Georgian             | 65          |      |
+``la``  | Latin                | 850         |      |
+``lb``  | Luxembourgish        | 305         |      |
+``lt``  | Lithuanian           | 247         |      |
+``lv``  | Latvian              | 168         |      |
+``mk``  | Macedonian           | 57          |      |
+``ms``  | Malay                | 14          |      |
+``nb``  | Norwegian (Bokmål)   | 617         |      |
+``nl``  | Dutch                | 254         |0.91  | on UD-NL-Alpino
+``nn``  | Norwegian (Nynorsk)| || 
+``pl``  | Polish               | 3,733       |0.91  | on UD-PL-PDB
+``pt``  | Portuguese           | 933         |0.92  | on UD-PT-GSD
+``ro``  | Romanian             | 311         |      |
+``ru``  | Russian              | 607         |      | alternative: [pymorphy2](https://github.com/kmike/pymorphy2/)
+``se``  | Northern Sámi        | 113         |      | experimental
+``sk``  | Slovak               | 846         |0.92  | on UD SK-SNK
+``sl``  | Slovene              | 136         |      |
+``sq``  | Albanian             | 35          |      |
+``sv``  | Swedish              | 658         |      | alternative: [lemmy](https://github.com/sorenlind/lemmy)
+``sw``  | Swahili              | 10          |      | experimental
+``tl``  | Tagalog              | 33          |      | experimental
+``tr``  | Turkish              | 1,333       |0.88  | on UD-TR-Boun
+``uk``  | Ukrainian            | 190         |      | alternative: [pymorphy2](https://github.com/kmike/pymorphy2)
+
+
+
+**Low coverage** mentions means one would probably be better off with a language-specific library, but *simplemma* will work to a limited extent. Open-source alternatives for Python are referenced if possible.
+
+**Experimental** mentions indicate that the language remains untested or that there could be issues with the underlying data or lemmatization process.
+
+The scores are calculated on [Universal Dependencies](https://universaldependencies.org) treebanks on single word tokens (including some contractions but not merged prepositions), they describe to what extent simplemma can accurately map tokens to their lemma form. They can be reproduced by concatenating all available UD files and by using the script `udscore.py` in the `training/` folder.
+
+This library is particularly relevant as regards the lemmatization of less frequent words. Its performance in this case is only incidentally captured by the benchmark above. In some languages, a fixed number of words such as pronouns can be further mapped by hand to enhance performance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,64 @@
+site_name: Simplemma
+
+theme:
+  name: "material"
+  palette: 
+
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/weather-night 
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - toc.follow
+
+extra_css:
+  - css/mkdocstrings.css
+
+repo_url: https://github.com/adbar/simplemma
+
+plugins:
+  - search:
+      lang: en
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            group_by_category: true
+            show_category_heading: true
+
+
+nav:
+  - Introduction: index.md
+  - Reference:
+    - Lemmatizer: reference/lemmatizer.md
+    - Language Detector: reference/language_detector.md
+    - Tokenizer: reference/tokenizer.md
+    - TokenSampler: reference/token_sampler.md
+    - Utils: reference/utils.md
+    - Strategies:
+      - Lemmatization Strategy: reference/strategies/lemmatization_strategy.md
+      - Dictionary Lookup Strategy: reference/strategies/dictionary_lookup.md
+      - Greedy Dictionary Lookup Strategy: reference/strategies/greedy_dictionary_lookup.md
+      - Hyphen removal Strategy: reference/strategies/hyphen_removal.md
+      - Rules Strategy: reference/strategies/rules.md
+      - Prefix Decomposition Strategy: reference/strategies/prefix_decomposition.md
+      - Affix Decomposition Strategy: reference/strategies/affix_decomposition.md
+      - Default Strategy: reference/strategies/default.md
+      - Fallback Strategies:
+        - Lemmatization Fallback Strategy: reference/strategies/fallback/lemmatization_fallback_strategy.md
+        - To Lowercase Strategy: reference/strategies/fallback/to_lowercase.md
+        - Raise Error Strategy: reference/strategies/fallback/raise_error.md
+      - Dictionaries:
+        - Dictionary Factory: reference/strategies/dictionaries/dictionary_factory.md
+  - Languages Supported: supported-languages.md
+  - Contributing: contributing.md
+  - Credit & Licenses: credit-and-licenses.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.4.3
+mkdocs-material==9.1.14
+mkdocstrings-python==1.0.0

--- a/simplemma/language_detector.py
+++ b/simplemma/language_detector.py
@@ -1,12 +1,10 @@
 """
-This module implements a language detection functionality using lemmatization and token sampling.
+Lemmatizer module.
+Provides classes for text language detection using lemmatization and token sampling.
 
-Classes:
-- LanguageDetector: A class that performs language detection using lemmatization and token sampling.
-
-Functions:
-- in_target_language: Calculate the proportion of text in the target language(s).
-- langdetect: Detect the language(s) of the given text and their proportions.
+- [LanguageDetector][simplemma.language_detector.LanguageDetector]: Class for performing language detection using lemmatization and token sampling.
+- [in_target_language()][simplemma.language_detector.in_target_language]: A legacy function that wraps the LanguageDetector's [is_known()][simplemma.language_detector.LanguageDetector.proportion_in_each_language] method.
+- [langdetect()][simplemma.language_detector.langdetect]: A legacy function that wraps the LanguageDetector's [is_known()][simplemma.language_detector.LanguageDetector.proportion_in_target_languages] method.
 """
 
 from operator import itemgetter
@@ -105,14 +103,7 @@ def _as_list(results: Dict[str, float]) -> List[Tuple[str, float]]:
 
 
 class LanguageDetector:
-    """
-    A class that performs language detection using lemmatization and token sampling.
-
-    Methods:
-        proportion_in_each_language: Calculate the proportion of each language in the given text.
-        proportion_in_target_languages: Calculate the proportion of text in the target language(s).
-        main_language: Determine the main language of the given text.
-    """
+    """A class that performs language detection using lemmatization and token sampling."""
 
     __slots__ = [
         "_lang",

--- a/simplemma/lemmatizer.py
+++ b/simplemma/lemmatizer.py
@@ -1,14 +1,12 @@
 """
-This module implements a Lemmatizer class and related functions for lemmatizing tokens and text in various languages.
+Lemmatizer module.
+Provides classes for lemmatizing token and full texts.
 
-Classes:
-- Lemmatizer: A class that provides lemmatization functionality using different strategies.
-
-Functions:
-- is_known: Check if a token is known in the given language(s).
-- lemmatize: Lemmatize a token in the given language(s).
-- text_lemmatizer: Lemmatize text in the given language(s).
-- lemma_iterator: Iterate over lemmatized tokens in the given text.
+- [Lemmatizer][simplemma.lemmatizer.Lemmatizer]: Class for performing token and full text lemmatization.
+- [is_known()][simplemma.lemmatizer.is_known]: A legacy function that wraps the Lemmatizer's [is_known()][simplemma.lemmatizer.Lemmatizer.is_known] method.
+- [lemmatize()][simplemma.lemmatizer.lemmatize]: A legacy function that wraps the Lemmatizer's [lemmatize()][simplemma.lemmatizer.Lemmatizer.lemmatize] method.
+- [text_lemmatizer()][simplemma.lemmatizer.text_lemmatizer]: A legacy function that wraps the Lemmatizer's [text_lemmatizer()][simplemma.lemmatizer.Lemmatizer.get_lemmas_in_text] method.
+- [lemma_iterator()][simplemma.lemmatizer.lemma_iterator]: A legacy function that wraps the Lemmatizer's [lemma_iterator()][simplemma.lemmatizer.Lemmatizer.get_lemmas_in_text] method.
 """
 
 from functools import lru_cache
@@ -133,22 +131,13 @@ def lemma_iterator(
 
 
 class Lemmatizer:
-    """Lemmatizer class for performing token lemmatization.
-
-    Methods:
-        is_known(token: str, lang: Union[str, Tuple[str, ...]]) -> bool:
-            Checks if a token is known in a given language.
-        lemmatize(token: str, lang: Union[str, Tuple[str, ...]]) -> str:
-            Lemmatizes a token in a given language.
-        get_lemmas_in_text(text: str, lang: Union[str, Tuple[str, ...]]) -> Iterator[str]:
-            Returns an iterator over the lemmas in a text in a given language.
-    """
+    """Lemmatizer class for performing token lemmatization."""
 
     __slots__ = [
+        "_cached_lemmatize",
         "_fallback_lemmatization_strategy",
         "_lemmatization_strategy",
         "_tokenizer",
-        "lemmatize",
     ]
 
     def __init__(
@@ -175,7 +164,7 @@ class Lemmatizer:
         self._tokenizer = tokenizer
         self._lemmatization_strategy = lemmatization_strategy
         self._fallback_lemmatization_strategy = fallback_lemmatization_strategy
-        self.lemmatize = lru_cache(maxsize=cache_max_size)(self._lemmatize)
+        self._cached_lemmatize = lru_cache(maxsize=cache_max_size)(self._lemmatize)
 
     def is_known(
         self,
@@ -200,6 +189,22 @@ class Lemmatizer:
             dictionary_lookup.get_lemma(token, lang_code) is not None
             for lang_code in lang
         )
+
+    def lemmatize(
+        self,
+        token: str,
+        lang: Union[str, Tuple[str, ...]],
+    ) -> str:
+        """Get the lemmatized form of a given word in the specified language(s).
+
+        Args:
+            token: The token to lemmatize.
+            lang: The language or languages for lemmatization.
+
+        Returns:
+            str: The lemmatized form of the token.
+        """
+        return self._cached_lemmatize(token, lang)
 
     def _lemmatize(
         self,

--- a/simplemma/strategies/affix_decomposition.py
+++ b/simplemma/strategies/affix_decomposition.py
@@ -1,3 +1,7 @@
+"""
+This file defines the `AffixDecompositionStrategy` class, which implements an affix decomposition lemmatization strategy in the Simplemma library.
+"""
+
 from typing import Optional
 
 from .lemmatization_strategy import LemmatizationStrategy
@@ -36,17 +40,6 @@ class AffixDecompositionStrategy(LemmatizationStrategy):
     This strategy decomposes tokens into affixes and looks up their lemmas in a dictionary.
     It first attempts to decompose the token using affix decomposition and then falls back
     to suffix decomposition if affix decomposition fails.
-
-    Args:
-        greedy (bool): Flag indicating whether to use a greedy approach for decomposition.
-        dictionary_lookup (DictionaryLookupStrategy, optional): The dictionary lookup strategy
-            to use for retrieving lemma information. Defaults to `DictionaryLookupStrategy()`.
-        greedy_dictionary_lookup (GreedyDictionaryLookupStrategy, optional): The greedy dictionary
-            lookup strategy to use for retrieving lemma information in the greedy approach.
-            Defaults to `GreedyDictionaryLookupStrategy()`.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language by performing subword decomposition.
     """
 
     __slots__ = ["_greedy", "_dictionary_lookup", "_greedy_dictionary_lookup"]

--- a/simplemma/strategies/default.py
+++ b/simplemma/strategies/default.py
@@ -1,16 +1,6 @@
 """
-Default Strategy
-----------------
-
 This module defines the `DefaultStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization using a combination of different strategies such as dictionary lookup, hyphen removal, rule-based lemmatization, prefix decomposition, and affix decomposition.
-
-Module Dependencies:
-- typing.Optional: For representing an optional return value.
-
-Class:
-- `DefaultStrategy`: A lemmatization strategy that combines different lemmatization techniques.
-
 """
 
 from typing import Optional
@@ -27,22 +17,8 @@ from .affix_decomposition import AffixDecompositionStrategy
 
 class DefaultStrategy(LemmatizationStrategy):
     """
-    Default Strategy
-
     This class represents a lemmatization strategy that combines different techniques to perform lemmatization.
     It implements the `LemmatizationStrategy` protocol.
-
-    Attributes:
-    - `_dictionary_lookup` (DictionaryLookupStrategy): A strategy for dictionary lookup.
-    - `_hyphen_search` (HyphenRemovalStrategy): A strategy for lemmatization by removing hyphens.
-    - `_rules_search` (RulesStrategy): A strategy for rule-based lemmatization.
-    - `_prefix_search` (PrefixDecompositionStrategy): A strategy for lemmatization by prefix decomposition.
-    - `_greedy_dictionary_lookup` (Optional[GreedyDictionaryLookupStrategy]): A strategy for dictionary lookup with a greedy approach.
-    - `_affix_search` (AffixDecompositionStrategy): A strategy for lemmatization by affix decomposition.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language using the combination of different techniques.
-
     """
 
     __slots__ = [
@@ -63,9 +39,9 @@ class DefaultStrategy(LemmatizationStrategy):
         Initialize the Default Strategy.
 
         Args:
-        - `greedy` (bool): Whether to use a greedy approach for dictionary lookup. Defaults to `False`.
-        - `dictionary_factory` (DictionaryFactory): A factory for creating dictionaries.
-            Defaults to `DefaultDictionaryFactory()`.
+            greedy (bool): Whether to use a greedy approach for dictionary lookup. Defaults to `False`.
+            dictionary_factory (DictionaryFactory): A factory for creating dictionaries.
+                Defaults to [`DefaultDictionaryFactory()`][simplemma.strategies.dictionaries.dictionary_factory.DefaultDictionaryFactory]..
 
         """
         self._greedy = greedy
@@ -87,11 +63,11 @@ class DefaultStrategy(LemmatizationStrategy):
         Get the lemma for a given token and language using the combination of different lemmatization techniques.
 
         Args:
-        - `token` (str): The token to lemmatize.
-        - `lang` (str): The language of the token.
+            token (str): The token to lemmatize.
+            lang (str): The language of the token.
 
         Returns:
-        - Optional[str]: The lemma of the token, or None if no lemma is found.
+            Optional[str]: The lemma of the token, or None if no lemma is found.
 
         """
         # filters

--- a/simplemma/strategies/dictionaries/dictionary_factory.py
+++ b/simplemma/strategies/dictionaries/dictionary_factory.py
@@ -1,12 +1,11 @@
 """
-Dictionary Factory
-------------------
+This module defines the `DictionaryFactory` protocol and the `DefaultDictionaryFactory` class.
+It provides functionality for loading and accessing dictionaries for supported languages.
 
-This file defines the `DictionaryFactory` protocol and the `DefaultDictionaryFactory` class. It provides functionality for loading and accessing dictionaries for supported languages.
+- [DictionaryFactory][simplemma.strategies.dictionaries.DictionaryFactory]: The Protocol class for all dictionary factories.
+- [DefaultDictionaryFactory][simplemma.strategies.dictionaries.DefaultDictionaryFactory]: Default dictionary factory.
+It loads the dictionaries that are shipped with simplemma and caches them as configured.
 
-Classes:
-- `DictionaryFactory`: A protocol defining the interface for a dictionary factory.
-- `DefaultDictionaryFactory`: A concrete implementation of the `DictionaryFactory` protocol.
 """
 
 import lzma
@@ -59,14 +58,10 @@ def _load_dictionary_from_disk(langcode: str) -> Dict[str, str]:
 
 class DictionaryFactory(Protocol):
     """
-    Dictionary Factory protocol.
-
     This protocol defines the interface for a dictionary factory, which is responsible for loading and providing access to dictionaries for different languages.
 
-    Methods:
-    - `get_dictionary(lang: str) -> Dict[str, str]`: Get the dictionary for a specific language.
-
     Note:
+        This protocol should be implemented by concrete dictionary factories.
         Concrete implementations of this protocol should provide a concrete implementation for the `get_dictionary` method.
     """
 
@@ -94,17 +89,8 @@ class DefaultDictionaryFactory(DictionaryFactory):
     """
     Default Dictionary Factory.
 
-    This class is a concrete implementation of the `DictionaryFactory` protocol. It provides functionality for loading and caching dictionaries from disk.
-
-    Attributes:
-    - `_data`: A dictionary to cache loaded dictionaries.
-    - `_load_dictionary_from_disk`: A cached version of the `_load_dictionary_from_disk` function.
-
-    Methods:
-    - `get_dictionary(lang: str) -> Dict[str, str]`: Get the dictionary for a specific language.
-
-    Note:
-        This class assumes that the dictionary files are stored in the 'data' folder relative to this module.
+    This class is a concrete implementation of the `DictionaryFactory` protocol.
+    It provides functionality for loading and caching dictionaries from disk that are included in Simplemma.
     """
 
     __slots__ = ["_data", "_load_dictionary_from_disk"]

--- a/simplemma/strategies/dictionary_lookup.py
+++ b/simplemma/strategies/dictionary_lookup.py
@@ -1,16 +1,6 @@
 """
-Dictionary Lookup Strategy
---------------------------
-
 This module defines the `DictionaryLookupStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization using dictionary lookup.
-
-Module Dependencies:
-- typing.Optional: For representing an optional return value.
-
-Class:
-- `DictionaryLookupStrategy`: A lemmatization strategy based on dictionary lookup.
-
 """
 
 from typing import Optional
@@ -20,16 +10,7 @@ from .lemmatization_strategy import LemmatizationStrategy
 
 
 class DictionaryLookupStrategy(LemmatizationStrategy):
-    """
-    Dictionary Lookup Strategy
-
-    This class represents a lemmatization strategy that performs lemmatization by looking up words in a dictionary.
-    It implements the `LemmatizationStrategy` protocol.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language using dictionary lookup.
-
-    """
+    """Dictionary Lookup Strategy"""
 
     __slots__ = ["_dictionary_factory"]
 
@@ -40,8 +21,8 @@ class DictionaryLookupStrategy(LemmatizationStrategy):
         Initialize the Dictionary Lookup Strategy.
 
         Args:
-        - `dictionary_factory` (DictionaryFactory): The dictionary factory used to obtain language dictionaries.
-            Defaults to `DefaultDictionaryFactory()`.
+            dictionary_factory (DictionaryFactory): The dictionary factory used to obtain language dictionaries.
+                Defaults to [`DefaultDictionaryFactory()`][simplemma.strategies.dictionaries.dictionary_factory.DefaultDictionaryFactory].
         """
         self._dictionary_factory = dictionary_factory
 
@@ -53,11 +34,11 @@ class DictionaryLookupStrategy(LemmatizationStrategy):
         It returns the lemma if found, or `None` if not found.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - Optional[str]: The lemma for the token, or `None` if not found in the dictionary.
+            Optional[str]: The lemma for the token, or `None` if not found in the dictionary.
 
         """
         # Search the language data, reverse case to extend coverage.

--- a/simplemma/strategies/fallback/lemmatization_fallback_strategy.py
+++ b/simplemma/strategies/fallback/lemmatization_fallback_strategy.py
@@ -1,13 +1,6 @@
 """
-Lemmatization Fallback Strategy
--------------------------------
-
-This file defines the `LemmatizationFallbackStrategy` protocol, which represents the interface for lemmatization fallback strategies in the Simplemma library.
+This module defines the `LemmatizationFallbackStrategy` protocol, which represents the interface for lemmatization fallback strategies in the Simplemma library.
 `LemmatizationFallbackStrategy` are used as a fallback strategy when a token's lemma cannot be determined using other lemmatization strategies.
-
-Classes:
-- `LemmatizationFallbackStrategy`: A protocol defining the interface for lemmatization fallback strategies.
-
 """
 
 import sys
@@ -21,18 +14,12 @@ else:
 
 class LemmatizationFallbackStrategy(Protocol):
     """
-    Protocol for Lemmatization Fallback Strategies.
+    This protocol defines the interface for lemmatization fallback strategies in the Simplemma library.
+    Fallback strategies are used when a token's lemma cannot be determined using other lemmatization strategies.
 
-    LemmatizationFallbackStrategy is a protocol that defines the interface for lemmatization fallback strategies
-    in the Simplemma library. Fallback strategies are used when a token's lemma cannot be determined using other
-    lemmatization strategies.
-
-    Note:
-        This protocol should be implemented by concrete fallback strategy classes.
-
-    Methods:
-    - `get_lemma(token: str, lang: str) -> str`: Retrieves the lemma of a given token in the specified language.
-
+     Note:
+         This protocol should be implemented by concrete fallback strategy classes.
+         Concrete implementations of this protocol should provide a concrete implementation for the `get_lemma` method.
     """
 
     @abstractmethod

--- a/simplemma/strategies/fallback/raise_error.py
+++ b/simplemma/strategies/fallback/raise_error.py
@@ -1,11 +1,5 @@
 """
-Raise Error Fallback Strategy
-----------------------------
-
-This file defines the `RaiseErrorFallbackStrategy` class, which is a concrete implementation of the `LemmatizationFallbackStrategy` protocol. It represents a fallback strategy that raises a `ValueError` when the lemma of a token cannot be determined.
-
-Classes:
-- `RaiseErrorFallbackStrategy`: A concrete implementation of the `LemmatizationFallbackStrategy` protocol.
+This module defines the `RaiseErrorFallbackStrategy` class, which is a concrete implementation of the `LemmatizationFallbackStrategy` protocol. It represents a fallback strategy that raises a `ValueError` when the lemma of a token cannot be determined.
 """
 
 from .lemmatization_fallback_strategy import LemmatizationFallbackStrategy
@@ -14,13 +8,8 @@ from .lemmatization_fallback_strategy import LemmatizationFallbackStrategy
 class RaiseErrorFallbackStrategy(LemmatizationFallbackStrategy):
     """
     Raise Error Fallback Strategy.
-
     RaiseErrorFallbackStrategy is a concrete implementation of the LemmatizationFallbackStrategy protocol. It represents
     a fallback strategy that raises a ValueError when the lemma of a token cannot be determined.
-
-    Methods:
-    - `get_lemma(token: str, lang: str) -> str`: Raises a ValueError indicating that the token was not found.
-
     """
 
     def get_lemma(self, token: str, lang: str) -> str:

--- a/simplemma/strategies/fallback/to_lowercase.py
+++ b/simplemma/strategies/fallback/to_lowercase.py
@@ -1,11 +1,5 @@
 """
-To Lowercase Fallback Strategy
-------------------------------
-
-This file defines the `ToLowercaseFallbackStrategy` class, which is a concrete implementation of the `LemmatizationFallbackStrategy` protocol. It represents a fallback strategy that converts tokens to lowercase for specific languages.
-
-Classes:
-- `ToLowercaseFallbackStrategy`: A concrete implementation of the `LemmatizationFallbackStrategy` protocol.
+This module defines the `ToLowercaseFallbackStrategy` class, which is a concrete implementation of the `LemmatizationFallbackStrategy` protocol. It represents a fallback strategy that converts tokens to lowercase for specific languages.
 """
 
 from typing import Set
@@ -17,18 +11,8 @@ BETTER_LOWER = {"bg", "es", "hy", "lt", "lv", "pt", "sk", "uk"}
 
 class ToLowercaseFallbackStrategy(LemmatizationFallbackStrategy):
     """
-    To Lowercase Fallback Strategy.
-
     ToLowercaseFallbackStrategy is a concrete implementation of the LemmatizationFallbackStrategy protocol.
     It represents a fallback strategy that converts tokens to lowercase for specific languages.
-
-    Attributes:
-    - `_langs_to_lower` (Set[str]): The set of languages for which tokens should be converted to lowercase.
-
-    Methods:
-    - `__init__(langs_to_lower: Set[str] = BETTER_LOWER)`: Initializes the ToLowercaseFallbackStrategy with the specified set of languages to convert to lowercase.
-    - `get_lemma(token: str, lang: str) -> str`: Converts the token to lowercase if the language is in the set of languages to convert.
-
     """
 
     __slots__ = ["_langs_to_lower"]

--- a/simplemma/strategies/greedy_dictionary_lookup.py
+++ b/simplemma/strategies/greedy_dictionary_lookup.py
@@ -1,16 +1,6 @@
 """
-Greedy Dictionary Lookup Strategy
----------------------------------
-
 This module defines the `GreedyDictionaryLookupStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization using a greedy dictionary lookup strategy.
-
-Module Dependencies:
-- typing.Optional: For representing an optional return value.
-
-Class:
-- `GreedyDictionaryLookupStrategy`: A lemmatization strategy based on greedy dictionary lookup.
-
 """
 
 from typing import Optional
@@ -24,19 +14,7 @@ SHORTER_GREEDY = {"bg", "et", "fi"}
 
 class GreedyDictionaryLookupStrategy(LemmatizationStrategy):
     """
-    Greedy Dictionary Lookup Strategy
-
     This class represents a lemmatization strategy that performs lemmatization using a greedy dictionary lookup strategy.
-    It implements the `LemmatizationStrategy` protocol.
-
-    Attributes:
-    - `_dictionary_factory` (DictionaryFactory): The dictionary factory used to obtain language dictionaries.
-    - `_distance` (int): The maximum allowed Levenshtein distance between candidate lemmas.
-    - `_steps` (int): The maximum number of lemmatization steps to perform.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language using the greedy dictionary lookup strategy.
-
     """
 
     __slots__ = ["_dictionary_factory", "_distance", "_steps"]
@@ -51,10 +29,10 @@ class GreedyDictionaryLookupStrategy(LemmatizationStrategy):
         Initialize the Greedy Dictionary Lookup Strategy.
 
         Args:
-        - `dictionary_factory` (DictionaryFactory): The dictionary factory used to obtain language dictionaries.
-            Defaults to `DefaultDictionaryFactory()`.
-        - `steps` (int): The maximum number of lemmatization steps to perform. Defaults to `1`.
-        - `distance` (int): The maximum allowed Levenshtein distance between candidate lemmas. Defaults to `5`.
+            dictionary_factory (DictionaryFactory): The dictionary factory used to obtain language dictionaries.
+                Defaults to [`DefaultDictionaryFactory()`][simplemma.strategies.dictionaries.dictionary_factory.DefaultDictionaryFactory]..
+            steps (int): The maximum number of lemmatization steps to perform. Defaults to `1`.
+            distance (int): The maximum allowed Levenshtein distance between candidate lemmas. Defaults to `5`.
 
         """
         self._dictionary_factory = dictionary_factory
@@ -70,11 +48,11 @@ class GreedyDictionaryLookupStrategy(LemmatizationStrategy):
         It returns the resulting lemma after the specified number of steps or when the conditions are not met.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - str: The lemma for the token.
+            str: The lemma for the token.
 
         """
         limit = 6 if lang in SHORTER_GREEDY else 8

--- a/simplemma/strategies/hyphen_removal.py
+++ b/simplemma/strategies/hyphen_removal.py
@@ -1,17 +1,6 @@
 """
-Hyphen Removal Strategy
------------------------
-
 This module defines the `HyphenRemovalStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization by removing hyphens from tokens and attempting to find dictionary forms.
-
-Module Dependencies:
-- typing.Optional: For representing an optional return value.
-- re: For working with regular expressions.
-
-Class:
-- `HyphenRemovalStrategy`: A lemmatization strategy based on hyphen removal.
-
 """
 
 import re
@@ -28,18 +17,9 @@ HYPHEN_REGEX = re.compile(rf"([{HYPHENS_FOR_REGEX}])")
 
 class HyphenRemovalStrategy(LemmatizationStrategy):
     """
-    Hyphen Removal Strategy
-
     This class represents a lemmatization strategy that performs lemmatization by removing hyphens from tokens
     and attempting to find dictionary forms.
     It implements the `LemmatizationStrategy` protocol.
-
-    Attributes:
-    - `_dictionary_lookup` (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language by removing hyphens and performing dictionary lookup.
-
     """
 
     __slots__ = ["_dictionary_lookup"]
@@ -51,7 +31,7 @@ class HyphenRemovalStrategy(LemmatizationStrategy):
         Initialize the Hyphen Removal Strategy.
 
         Args:
-        - `dictionary_lookup` (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
+            dictionary_lookup (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
                 Defaults to `DictionaryLookupStrategy()`.
 
         """
@@ -69,11 +49,11 @@ class HyphenRemovalStrategy(LemmatizationStrategy):
         If no dictionary form is found, None is returned.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - Optional[str]: The lemma for the token, or None if no lemma is found.
+            Optional[str]: The lemma for the token, or None if no lemma is found.
 
         """
         token_parts = HYPHEN_REGEX.split(token)

--- a/simplemma/strategies/lemmatization_strategy.py
+++ b/simplemma/strategies/lemmatization_strategy.py
@@ -1,11 +1,5 @@
 """
-Affix Decomposition Strategy
-----------------------------
-
-This file defines the `AffixDecompositionStrategy` class, which implements an affix decomposition lemmatization strategy in the Simplemma library.
-
-Classes:
-- `AffixDecompositionStrategy`: A lemmatization strategy that uses affix decomposition to find lemmas of tokens.
+This file defines the `LemmatizationStrategy` protocl class, which all lemmatization strategies should extend to be usable by the Simplemma library.
 """
 
 import sys
@@ -20,33 +14,29 @@ else:
 
 class LemmatizationStrategy(Protocol):
     """
-    Lemmatization Strategy Protocol
-
     This protocol defines the interface for lemmatization strategies. Subclasses implementing this protocol
     must provide an implementation for the `get_lemma` method.
 
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language.
-
+    Note:
+        This protocol should be implemented by concrete lemmatization strategy classes.
+        Concrete implementations of this protocol should provide a concrete implementation for the `get_lemma` method.
     """
 
     @abstractmethod
     def get_lemma(self, token: str, lang: str) -> Optional[str]:
         """
-        Get Lemma
-
         This method receives a token and a language code and should return the lemma for the token in the specified language.
         If the lemma is not found, it should return `None`.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - Optional[str]: The lemma for the token, or `None` if not found.
+            Optional[str]: The lemma for the token, or `None` if not found.
 
         Raises:
-        - NotImplementedError: If the method is not implemented by the subclass.
+            NotImplementedError: If the method is not implemented by the subclass.
 
         """
         raise NotImplementedError()

--- a/simplemma/strategies/prefix_decomposition.py
+++ b/simplemma/strategies/prefix_decomposition.py
@@ -1,18 +1,6 @@
 """
-Prefix Decomposition Strategy
-----------------------------
-
 This module defines the `PrefixDecompositionStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization by performing subword decomposition using pre-defined prefixes.
-
-Module Dependencies:
-- typing.Dict: For representing a dictionary of known prefixes.
-- typing.Optional: For representing an optional return value.
-- typing.Pattern: For representing a compiled regular expression pattern.
-
-Class:
-- `PrefixDecompositionStrategy`: A lemmatization strategy based on prefix decomposition.
-
 """
 
 from typing import Dict, Optional, Pattern
@@ -25,18 +13,8 @@ from .lemmatization_strategy import LemmatizationStrategy
 
 class PrefixDecompositionStrategy(LemmatizationStrategy):
     """
-    Prefix Decomposition Strategy
-
     This class represents a lemmatization strategy that performs lemmatization by performing subword decomposition using pre-defined prefixes.
     It implements the `LemmatizationStrategy` protocol.
-
-    Attributes:
-    - `_known_prefixes` (Dict[str, Pattern[str]]): A dictionary of known prefixes for various languages.
-    - `_dictionary_lookup` (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language by performing subword decomposition.
-
     """
 
     __slots__ = ["_known_prefixes", "_dictionary_lookup"]
@@ -50,9 +28,9 @@ class PrefixDecompositionStrategy(LemmatizationStrategy):
         Initialize the Prefix Decomposition Strategy.
 
         Args:
-        - `known_prefixes` (Dict[str, Pattern[str]]): A dictionary of known prefixes for various languages.
-            Defaults to `DEFAULT_KNOWN_PREFIXES`.
-        - `dictionary_lookup` (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
+            known_prefixes (Dict[str, Pattern[str]]): A dictionary of known prefixes for various languages.
+                Defaults to `DEFAULT_KNOWN_PREFIXES`.
+            dictionary_lookup (DictionaryLookupStrategy): The dictionary lookup strategy used to find dictionary forms.
                 Defaults to `DictionaryLookupStrategy()`.
 
         """
@@ -70,11 +48,11 @@ class PrefixDecompositionStrategy(LemmatizationStrategy):
         If no known prefix is found or no lemma is found for the subword, None is returned.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - Optional[str]: The lemma for the token, or None if no lemma is found.
+            Optional[str]: The lemma for the token, or None if no lemma is found.
 
         """
         if lang not in self._known_prefixes:

--- a/simplemma/strategies/rules.py
+++ b/simplemma/strategies/rules.py
@@ -1,18 +1,6 @@
 """
-Rules Strategy
---------------
-
 This module defines the `RulesStrategy` class, which is a concrete implementation of the `LemmatizationStrategy` protocol.
 It provides lemmatization by applying pre-defined rules for each language.
-
-Module Dependencies:
-- typing.Callable: For representing a callable object.
-- typing.Dict: For representing a dictionary of rules.
-- typing.Optional: For representing an optional return value.
-
-Class:
-- `RulesStrategy`: A lemmatization strategy based on pre-defined rules.
-
 """
 
 from typing import Callable, Dict, Optional
@@ -24,17 +12,8 @@ from .lemmatization_strategy import LemmatizationStrategy
 
 class RulesStrategy(LemmatizationStrategy):
     """
-    Rules Strategy
-
     This class represents a lemmatization strategy that performs lemmatization by applying pre-defined rules for each language.
     It implements the `LemmatizationStrategy` protocol.
-
-    Attributes:
-    - `_rules` (Dict[str, Callable[[str], Optional[str]]]): A dictionary of pre-defined rules for various languages.
-
-    Methods:
-    - `get_lemma`: Get the lemma for a given token and language by applying pre-defined rules.
-
     """
 
     __slots__ = ["_rules"]
@@ -46,8 +25,8 @@ class RulesStrategy(LemmatizationStrategy):
         Initialize the Rules Strategy.
 
         Args:
-        - `rules` (Dict[str, Callable[[str], Optional[str]]]): A dictionary of pre-defined rules for various languages.
-          Defaults to `DEFAULT_RULES`.
+            rules (Dict[str, Callable[[str], Optional[str]]]): A dictionary of pre-defined rules for various languages.
+                Defaults to `DEFAULT_RULES`.
 
         """
         self._rules = rules
@@ -63,11 +42,11 @@ class RulesStrategy(LemmatizationStrategy):
         If no rules are defined for the language or no lemma is found, None is returned.
 
         Args:
-        - `token` (str): The input token to lemmatize.
-        - `lang` (str): The language code for the token's language.
+            token (str): The input token to lemmatize.
+            lang (str): The language code for the token's language.
 
         Returns:
-        - Optional[str]: The lemma for the token, or None if no lemma is found.
+            Optional[str]: The lemma for the token, or None if no lemma is found.
 
         """
         if lang not in self._rules:

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -1,10 +1,12 @@
 """
-Sampler module. Provides classes for sampling tokens from text.
+Token Sampler module.
+Provides classes for sampling tokens from text.
 
-- TokenSampler: An abstract base class for token samplers.
-- BaseTokenSampler: A base class for token samplers with common functionality.
-- MostCommonTokenSampler: A token sampler that selects the most common tokens.
-- RelaxedMostCommonTokenSampler: A relaxed version of the most common token sampler.
+- [TokenSampler][simplemma.token_sampler.TokenSampler]: The Protocol class for all token samplers.
+- [BaseTokenSampler][simplemma.token_sampler.BaseTokenSampler]: An abstract base class for token samplers implementing tokenization using
+a [Tokenizer][simplemma.tokenizer.Tokenizer] so the user only has to implement the sampling strategy.
+- [MostCommonTokenSampler][simplemma.token_sampler.MostCommonTokenSampler]: A token sampler that selects the most common tokens.
+- [RelaxedMostCommonTokenSampler][simplemma.token_sampler.RelaxedMostCommonTokenSampler]: A relaxed version of the most common token sampler.
 
 """
 
@@ -67,17 +69,6 @@ class BaseTokenSampler(ABC, TokenSampler):
     BaseTokenSampler is the base class for token samplers.
     It uses the given Tokenizer to convert a text in token.
     Classes inheriting from BaseTokenSampler only have to implement sample_tokens.
-
-    Args:
-        tokenizer (Tokenizer, optional): The tokenizer to use for splitting text into tokens.
-            Defaults to `RegexTokenizer(SPLIT_INPUT)`.
-
-    Methods:
-        sample_text(text: str) -> List[str]:
-            Samples tokens from the given text.
-
-        sample_tokens(tokens: List[str]) -> List[str]:
-            Samples tokens from the given list of tokens.
     """
 
     __slots__ = ["_tokenizer"]
@@ -124,16 +115,7 @@ class BaseTokenSampler(ABC, TokenSampler):
 
 
 class MostCommonTokenSampler(BaseTokenSampler):
-    """
-    Token sampler that selects the most common tokens.
-
-    Methods:
-        sample_text(text: str) -> List[str]:
-            Samples tokens from the given text.
-
-        sample_tokens(tokens: List[str]) -> List[str]:
-            Samples tokens from the given list of tokens.
-    """
+    """Token sampler that selects the most common tokens."""
 
     __slots__ = ["_capitalized_threshold", "_sample_size"]
 
@@ -182,15 +164,7 @@ class MostCommonTokenSampler(BaseTokenSampler):
 class RelaxedMostCommonTokenSampler(MostCommonTokenSampler):
     """
     Relaxed version of the most common token sampler.
-
     This sampler uses a relaxed splitting regex pattern and allows for a larger sample size.
-
-    Methods:
-        sample_text(text: str) -> List[str]:
-            Samples tokens from the given text.
-
-        sample_tokens(tokens: List[str]) -> List[str]:
-            Samples tokens from the given list of tokens.
     """
 
     def __init__(

--- a/simplemma/tokenizer.py
+++ b/simplemma/tokenizer.py
@@ -1,14 +1,11 @@
 """
-Tokenizers module. Provides classes for text tokenization.
+Tokenizers module.
+Provides classes for text tokenization.
 
-Classes:
-- Tokenizer: An abstract base class for tokenizers.
-- RegexTokenizer: A tokenizer that uses regular expressions for tokenization.
-
-Functions:
-- simple_tokenizer: A simple tokenizer based on regular expressions.
-
-TODO ADD TOKREGEX
+- [Tokenizer][simplemma.tokenizer.Tokenizer]: The Protocol class for all tokenizers.
+- [RegexTokenizer][simplemma.tokenizer.RegexTokenizer]: A tokenizer based on a regular expresion.
+- [simple_tokenizer()][simplemma.tokenizer.simple_tokenizer]: A legacy function that wraps the RegexTokenizer's [split_text][simplemma.tokenizer.RegexTokenizer.split_text] method.
+- [TOKREGEX][simplemma.tokenizer.RegexTokenizer]: The regular expresion used by default by [RegexTokenizer][simplemma.tokenizer.RegexTokenizer].
 """
 
 import re
@@ -30,6 +27,7 @@ TOKREGEX = re.compile(
     r"[,;:\.?!¿¡‽⸮…()\[\]–{}—―/‒_“„”⹂‚‘’‛′″‟'\"«»‹›<>=+−×÷•·]+"
     r")"
 )
+"""The regular expresion used by default by [RegexTokenizer][simplemma.tokenizer.RegexTokenizer]."""
 
 
 def simple_tokenizer(text: str, splitting_regex: Pattern[str] = TOKREGEX) -> List[str]:
@@ -52,14 +50,8 @@ def simple_tokenizer(text: str, splitting_regex: Pattern[str] = TOKREGEX) -> Lis
 
 class Tokenizer(Protocol):
     """
-    Abstract base class for tokenizers.
-
+    Abstract base class for Tokenizers.
     Tokenizers are used to split a text into individual tokens.
-
-    Methods:
-        split_text(text: str) -> List[str]:
-            Splits the text into tokens using the specified regular expression pattern.
-
     """
 
     @abstractmethod
@@ -80,16 +72,7 @@ class Tokenizer(Protocol):
 class RegexTokenizer(Tokenizer):
     """
     Tokenizer that uses regular expressions to split a text into tokens.
-
     This tokenizer splits the input text using the specified regex pattern.
-
-    Args:
-        splitting_regex (Pattern[str], optional): The regular expression pattern used for tokenization.
-            Defaults to `TOKREGEX`.
-
-    Methods:
-        split_text(text: str) -> List[str]:
-            Splits the text into tokens using the specified regular expression pattern.
     """
 
     __slots__ = ["_splitting_regex"]

--- a/simplemma/utils.py
+++ b/simplemma/utils.py
@@ -1,8 +1,9 @@
 """
-Utils module. Contains utility functions for language processing.
+Utils module.
+Contains utility functions for language processing.
 
-- validate_lang_input: Validates the language input and ensures it is a valid tuple.
-- levenshtein_dist: Calculates the Levenshtein distance between two strings.
+- [levenshtein_dist][simplemma.utils.levenshtein_dist]: Calculates the Levenshtein distance between two strings.
+- [validate_lang_input][simplemma.utils.validate_lang_input]: Validates the language input and ensures it is a valid tuple.
 """
 
 from typing import Any, Tuple


### PR DESCRIPTION
mkdocs page for docs.

I don't know how familiar you are with GitHub Pages, but this can be easily published. See the following:
* https://www.mkdocs.org/user-guide/deploying-your-docs/
* https://squidfunk.github.io/mkdocs-material/publishing-your-site/


I would also be happy to configure that, but then you'd need to trust me with some higher permissions on the repo.


I suggest that we move all content to the page and keep the readme to a minimum with some pointers to the page.