### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
         include:
-        # custom tests
-        # other OS version necessary
-        - os: ubuntu-20.04
-          python-version: '3.6'
-        - os: ubuntu-20.04
-          python-version: '3.7'
         # common versions on MacOS
         - os: macos-latest
           python-version: '3.10'
@@ -62,15 +56,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      if: matrix.python-version != '3.6' && matrix.python-version != '3.7'
       run: pip install -r requirements-dev.txt
-
-    - name: Install dependencies (pytest)
-      run: python -m pip install --upgrade pytest pytest-cov
 
     # tests
     - name: Lint with flake8
-      if: matrix.python-version != '3.6' && matrix.python-version != '3.7'
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -78,11 +67,9 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Code format with black
-      if: matrix.python-version != '3.6' && matrix.python-version != '3.7'
       run: black --check --diff simplemma training tests
 
     - name: Type checking with mypy
-      if: matrix.python-version != '3.6' && matrix.python-version != '3.7'
       run: mypy -p simplemma -p training -p tests
 
     - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = ["pytest>=3", "pytest-cov"]
 setup(
     author="Adrien Barbaresi",
     author_email="barbaresi@bbaw.de",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[  # https://pypi.org/classifiers/
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -71,8 +71,6 @@ setup(
         "Natural Language :: Ukrainian",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/simplemma/strategies/dictionaries/dictionary_factory.py
+++ b/simplemma/strategies/dictionaries/dictionary_factory.py
@@ -10,17 +10,11 @@ It loads the dictionaries that are shipped with simplemma and caches them as con
 
 import lzma
 import pickle
-import sys
 from abc import abstractmethod
 from functools import lru_cache
 from os import listdir, path
 from pathlib import Path
-from typing import ByteString, Dict
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import ByteString, Dict, Protocol
 
 DATA_FOLDER = str(Path(__file__).parent / "data")
 SUPPORTED_LANGUAGES = [

--- a/simplemma/strategies/fallback/lemmatization_fallback_strategy.py
+++ b/simplemma/strategies/fallback/lemmatization_fallback_strategy.py
@@ -3,13 +3,9 @@ This module defines the `LemmatizationFallbackStrategy` protocol, which represen
 `LemmatizationFallbackStrategy` are used as a fallback strategy when a token's lemma cannot be determined using other lemmatization strategies.
 """
 
-import sys
 from abc import abstractmethod
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import Protocol
 
 
 class LemmatizationFallbackStrategy(Protocol):

--- a/simplemma/strategies/lemmatization_strategy.py
+++ b/simplemma/strategies/lemmatization_strategy.py
@@ -2,14 +2,8 @@
 This file defines the `LemmatizationStrategy` protocl class, which all lemmatization strategies should extend to be usable by the Simplemma library.
 """
 
-import sys
 from abc import abstractmethod
-from typing import Optional
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import Optional, Protocol
 
 
 class LemmatizationStrategy(Protocol):

--- a/simplemma/token_sampler.py
+++ b/simplemma/token_sampler.py
@@ -11,17 +11,11 @@ a [Tokenizer][simplemma.tokenizer.Tokenizer] so the user only has to implement t
 """
 
 import re
-import sys
 from abc import ABC, abstractmethod
 from collections import Counter
-from typing import Iterable, List
+from typing import Iterable, List, Protocol
 
 from .tokenizer import RegexTokenizer, Tokenizer
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 
 SPLIT_INPUT = re.compile(r"[^\W\d_]{3,}")

--- a/simplemma/tokenizer.py
+++ b/simplemma/tokenizer.py
@@ -9,14 +9,10 @@ Provides classes for text tokenization.
 """
 
 import re
-import sys
 from abc import abstractmethod
 from typing import Iterator, List, Pattern
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import Protocol
 
 TOKREGEX = re.compile(
     r"(?:"


### PR DESCRIPTION
Python 3.7 is end-of-life for a year now and Python 3.6 even longer, so let's drop support for them to not limit the use of Python language features to one supported by those outdated Python versions.