### PR TITLE
prepare v1.1.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@ History
 =======
 
 
+1.1.1
+-----
+
+- Fix `ModuleNotFoundError` and test optional dependencies (#142)
+- Simplify code and add missing type annotations (#144)
+
+
 1.1.0
 -----
 

--- a/simplemma/__init__.py
+++ b/simplemma/__init__.py
@@ -14,7 +14,7 @@ __title__ = "simplemma"
 __author__ = "Adrien Barbaresi, Juanjo Diaz and contributors"
 __email__ = "barbaresi@bbaw.de"
 __license__ = "MIT"
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 from .language_detector import LanguageDetector, in_target_language, langdetect


### PR DESCRIPTION
Release new version at once because `1.1.0` is failing.

@juanjoDiaz we can tackle the other issues later.