### PR TITLE
Maintenance: fix file opening in training/download-eval-data.py

### DIFF
--- a/training/download-eval-data.py
+++ b/training/download-eval-data.py
@@ -48,7 +48,8 @@ mkdir(CLEAN_DATA_FOLDER)
 
 log.info("Downloading evaluation data...")
 response = requests.get(DATA_URL)
-open(DATA_FILE, "wb").write(response.content)
+with open(DATA_FILE, "wb") as f:
+    f.write(response.content)
 
 log.info("Uncompressing evaluation data...")
 with tarfile.open(DATA_FILE) as tar:


### PR DESCRIPTION
Potential fix for [https://github.com/adbar/simplemma/security/code-scanning/42](https://github.com/adbar/simplemma/security/code-scanning/42)

To fix the issue, the `open(DATA_FILE, "wb")` statement should be replaced with a `with` statement. The `with` statement ensures that the file is properly closed after the `write` operation, even if an exception occurs. This change will make the code more robust and adhere to best practices for file handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
