### PR TITLE
Potential fix for code scanning alert no. 21: Arbitrary file write during tarfile extraction

### DIFF
--- a/training/download-eval-data.py
+++ b/training/download-eval-data.py
@@ -53,7 +53,11 @@ with open(DATA_FILE, "wb") as f:
 
 log.info("Uncompressing evaluation data...")
 with tarfile.open(DATA_FILE) as tar:
-    tar.extractall(DATA_FOLDER)
+    for member in tar.getmembers():
+        member_path = path.join(DATA_FOLDER, member.name)
+        if not member_path.startswith(path.abspath(DATA_FOLDER)):
+            raise ValueError(f"Illegal tar archive entry: {member.name}")
+        tar.extract(member, DATA_FOLDER)
 uncompressed_data_folder = path.join(
     DATA_FOLDER, glob(f"{DATA_FOLDER}/ud-treebanks-*")[0]
 )


### PR DESCRIPTION
Potential fix for [https://github.com/adbar/simplemma/security/code-scanning/21](https://github.com/adbar/simplemma/security/code-scanning/21)

To fix the issue, we need to validate the file paths in the tar archive before extracting them to ensure they do not contain directory traversal elements (`..`) or absolute paths. This can be achieved by iterating over the members of the tar archive, checking each member's path, and only extracting safe members. The `os.path` module can be used to perform these checks.

The fix involves:
1. Replacing the `tar.extractall(DATA_FOLDER)` call with a loop that validates each member's path.
2. Ensuring that the resolved path of each member is within the intended extraction directory (`DATA_FOLDER`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
